### PR TITLE
feat: add ID field to Habit admin details view

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -863,6 +863,30 @@ events = await maybe_await(
 
 **Why**: Trace data corruption, reconstruct user interactions, debug issues with state snapshots.
 
+## Django Admin Configuration
+
+### Displaying ID Fields in Details View
+
+To show the primary key (ID) field in Django admin details view:
+1. Add `'id'` to `readonly_fields` (primary keys are read-only)
+2. Add `'id'` to the appropriate fieldset (typically first field in the first fieldset)
+
+**Example** (`src/core/admin.py`):
+```python
+@admin.register(Habit)
+class HabitAdmin(admin.ModelAdmin):
+    readonly_fields = ['id', 'created_at', 'updated_at']
+    
+    fieldsets = (
+        ('Habit Information', {
+            'fields': ('id', 'user', 'name', 'weight', 'category', 'active')
+        }),
+        # ...
+    )
+```
+
+**Why**: ID fields are useful for debugging, API references, and cross-referencing records.
+
 ## Django Admin Custom Actions
 
 **CRITICAL**: Django admin runs in WSGI (synchronous) context. Never use `asyncio.run()` or async service layer methods in admin actions.

--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -62,13 +62,13 @@ class HabitAdmin(admin.ModelAdmin):
     list_display = ['name', 'user', 'weight', 'category', 'active', 'created_at']
     list_filter = ['active', 'category', 'created_at', 'user']
     search_fields = ['name', 'category', 'user__name', 'user__telegram_id']
-    readonly_fields = ['created_at', 'updated_at']
+    readonly_fields = ['id', 'created_at', 'updated_at']
     ordering = ['user', 'name']
     autocomplete_fields = ['user']
 
     fieldsets = (
         ('Habit Information', {
-            'fields': ('user', 'name', 'weight', 'category', 'active')
+            'fields': ('id', 'user', 'name', 'weight', 'category', 'active')
         }),
         ('Timestamps', {
             'fields': ('created_at', 'updated_at'),


### PR DESCRIPTION
- Add 'id' to readonly_fields in HabitAdmin
- Display ID as first field in Habit Information fieldset
- Document pattern for displaying ID fields in Django admin

@codex review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds visibility of primary keys in the Habit admin and documents how to enable this pattern.
> 
> - Update `HabitAdmin` to include `id` in `readonly_fields` and display it first in the `Habit Information` fieldset
> - Extend `RULES.md` with a "Django Admin Configuration" section explaining how to show ID fields in admin details
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22b81ede10d93a09c12cbd1d49934fec789e546a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->