### PR TITLE
docs: update README and RULES to reflect migration from Airtable to D…

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,6 @@ All configuration is managed via environment variables in `.env`:
 
 ```env
 # Required
-AIRTABLE_API_KEY=your_key_here
-AIRTABLE_BASE_ID=your_base_id_here
 TELEGRAM_BOT_TOKEN=your_token_here
 LLM_PROVIDER=openai
 LLM_MODEL=gpt-3.5-turbo

--- a/RULES.md
+++ b/RULES.md
@@ -277,6 +277,8 @@ progress = RewardProgress(user_id=user_id, reward_id=reward_id)  # Avoid this!
 'created_at' → 'date_joined'     # DateTimeField from AbstractUser
 ```
 
+**Note**: The system has fully migrated from Airtable to Django ORM. All Airtable code has been removed. The `src/airtable/` directory no longer exists, and all repositories use Django models (`src/core/repositories.py`). The field mappings above are for historical reference only.
+
 ### Computed Values Pattern
 
 **Use regular methods instead of `@property` for computed values.** This provides better async compatibility.


### PR DESCRIPTION
…jango ORM

- Removed Airtable API key and base ID from README.
- Added note in RULES about the complete migration from Airtable to Django ORM, including the removal of the `src/airtable/` directory and the transition to Django models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs update for ORM migration**
> 
> - README: Removes `AIRTABLE_API_KEY` and `AIRTABLE_BASE_ID` from required `.env` vars
> - RULES: Adds explicit note that Airtable has been fully removed (no `src/airtable/`), with repositories now using Django models (`src/core/repositories.py`) and field mappings kept only for historical reference
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a41986845079ab8b296b3d8b24c37135a651005. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->