### PR TITLE
docs: plan default Real reward type and skip category in add flow

### DIFF
--- a/docs/features/0030_PLAN.md
+++ b/docs/features/0030_PLAN.md
@@ -1,0 +1,39 @@
+# Feature 0030 Plan: Default reward category to Real and hide it in creation flow
+
+## Context
+The reward creation flow should skip the “Category” step and default it to **Real**. The field should remain in storage and APIs, but it should not appear in any user-facing messages during reward creation. This plan implements: “during creation of a new reward let’s skip this the step Category and put Real by default and don’t show in any messages”.
+
+## Relevant Files & Functions
+- `src/bot/handlers/reward_handlers.py`
+  - `reward_name_received()` (currently transitions to type selection)
+  - `_format_reward_summary()` (includes reward type in confirmation)
+  - `reward_confirm_save()` (reads `reward_data['type']`)
+  - `add_reward_conversation` state transitions (type selection state)
+- `src/bot/messages.py`
+  - `HELP_ADD_REWARD_TYPE_PROMPT` and `HELP_ADD_REWARD_CONFIRM` content
+  - Reward-type button labels (still used by edit flow)
+- `src/bot/keyboards.py`
+  - `build_reward_type_keyboard()` (used by add flow today, remains for edit flow)
+- `tests/test_bot_handlers.py`
+  - Add/adjust tests for `/add_reward` flow expectations
+
+## Plan
+### 1) Update reward creation flow to default “Real” without a type step
+- In `reward_name_received()`, after storing the reward name, set `reward_data['type'] = RewardType.REAL` and immediately proceed to the weight prompt (skip `build_reward_type_keyboard()` and the type prompt message).
+- Remove the type-selection state from `add_reward_conversation` so the flow transitions directly from name → weight (keeping edit flow unchanged).
+- Ensure `reward_confirm_save()` still uses the stored type when calling `reward_service.create_reward()` so the backend field remains populated.
+
+### 2) Remove reward type from creation messages
+- Update `_format_reward_summary()` to omit the reward type from the confirmation summary for add flow.
+- Update `HELP_ADD_REWARD_CONFIRM` in `src/bot/messages.py` to remove the “Type” line so type is not shown in any confirmation message.
+- Leave `HELP_ADD_REWARD_TYPE_PROMPT` and type buttons intact for edit flow unless unused globally; do not surface them in the add flow.
+
+### 3) Tests
+Add or update tests in `tests/test_bot_handlers.py` to cover:
+- `/add_reward` flow skips the type step and immediately sends the weight prompt after name input.
+- Reward creation uses `RewardType.REAL` by default when no user input is provided.
+- Confirmation message for add flow does not include any type/category line.
+
+## Notes
+- No changes are required to models, migrations, or APIs; the reward type/category remains in the data model and edit flow.
+- If any localization keys become unused in add flow, leave them in place for edit flow to avoid breaking existing UX.


### PR DESCRIPTION
### Motivation
- Add a concise technical plan to default the reward type to `Real` and remove the category/type step from the `/add_reward` conversational flow while keeping the field in storage and APIs.

### Description
- Create `docs/features/0030_PLAN.md` that lists changes to `src/bot/handlers/reward_handlers.py`, `src/bot/messages.py`, `src/bot/keyboards.py`, and `tests/test_bot_handlers.py`, and prescribes setting `reward_data['type'] = RewardType.REAL`, removing the add-flow type-selection state from `add_reward_conversation`, and omitting type from add-flow confirmation messages.

### Testing
- No automated tests were run for this documentation-only change; the plan instructs adding or updating tests in `tests/test_bot_handlers.py` to assert the type step is skipped, the default is `RewardType.REAL`, and the confirmation message does not display type/category.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971beb30b90833283ccf6a94898c20c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `docs/features/0030_PLAN.md` detailing a minimal UX change to the reward creation flow.
> 
> - Default `reward_data['type']` to `RewardType.REAL` in `reward_name_received()` and skip the type-selection step (name → weight)
> - Keep backend field; ensure `reward_confirm_save()` still passes the stored type
> - Remove type/category from add-flow confirmation output and prompts; retain type UI for edit flow
> - Notes and test plan to verify step-skipping, defaulting to Real, and omission of type in confirmations
> 
> This PR is documentation-only; no code or API changes included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 138ce9600d59105e731c3cf92a6658c172c3afc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->