### PR TITLE
feat: add langbot.habitreward.org reverse proxy to Caddyfile

### DIFF
--- a/deployment/caddy/Caddyfile
+++ b/deployment/caddy/Caddyfile
@@ -124,6 +124,45 @@ launchbuilder.habitreward.org {
         respond "{http.error.status_code} {http.error.status_text}"
     }
 }
+# Language Learning Bot - Subdomain
+langbot.habitreward.org {
+    # Automatic HTTPS via Let's Encrypt
+    tls erzhan.sarsenov@gmail.com
+
+    # Reverse proxy to Telegram webhook server on host
+    reverse_proxy host.docker.internal:8002 {
+        # Health check
+        health_uri /health
+        health_interval 30s
+        health_timeout 10s
+    }
+
+    # Security headers (same as main app)
+    header {
+        # HSTS
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        # Prevent clickjacking
+        X-Frame-Options "SAMEORIGIN"
+        # Prevent MIME sniffing
+        X-Content-Type-Options "nosniff"
+        # XSS protection
+        X-XSS-Protection "1; mode=block"
+        # Referrer policy
+        Referrer-Policy "strict-origin-when-cross-origin"
+    }
+
+    # Logging
+    log {
+        output file /var/log/caddy/langbot.log
+        format console
+    }
+
+    # Error handling
+    handle_errors {
+        respond "{http.error.status_code} {http.error.status_text}"
+    }
+}
+
 # Redirect www to non-www (if needed)
 www.habitreward.org {
     redir https://habitreward.org{uri} permanent


### PR DESCRIPTION
Add Caddy configuration for language learning bot subdomain, proxying to host.docker.internal:8002.