### PR TITLE
fix: update Telegram widget SRI hash

### DIFF
--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -86,7 +86,7 @@ onMounted(() => {
   }
 
   const WIDGET_URL = "https://telegram.org/js/telegram-widget.js?22";
-  const WIDGET_SRI = "sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb";
+  const WIDGET_SRI = "sha384-I+W8gJkm5OWQibtRzgVIojXtlJek6sKioAqefhZ4f0SodL9LyEGvj4zjPPFhStA0";
 
   function appendWidgetScript(useIntegrity) {
     const script = document.createElement("script");


### PR DESCRIPTION
## Summary
- Updated the `WIDGET_SRI` hash in `frontend/src/pages/Login.vue` to match the current hash served by `https://telegram.org/js/telegram-widget.js?22`
- Verified with `./scripts/verify_telegram_widget_sri.sh`

## Test plan
- [ ] Verify login page loads the Telegram widget successfully
- [ ] Confirm `./scripts/verify_telegram_widget_sri.sh` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)