### PR TITLE
fix: SECURE_SSL_REDIRECT breaking site behind Caddy

### DIFF
--- a/deployment/caddy/Caddyfile
+++ b/deployment/caddy/Caddyfile
@@ -13,6 +13,9 @@ habitreward.org {
         health_uri /admin/login/
         health_interval 30s
         health_timeout 10s
+        health_headers {
+            X-Forwarded-Proto "https"
+        }
     }
 
     # Static files

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - habit_reward_network
 
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/admin/login/')"]
+      test: ["CMD", "python", "-c", "import urllib.request; r=urllib.request.Request('http://localhost:8000/admin/login/',headers={'X-Forwarded-Proto':'https'}); urllib.request.urlopen(r)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/habit_reward_project/settings.py
+++ b/src/habit_reward_project/settings.py
@@ -41,6 +41,7 @@ CSRF_TRUSTED_ORIGINS = env.list('CSRF_TRUSTED_ORIGINS', default=[])
 # HTTPS enforcement and session security in production
 if not DEBUG:
     SECURE_SSL_REDIRECT = True
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
     SECURE_HSTS_SECONDS = 31536000  # 1 year


### PR DESCRIPTION
## Summary
- Django's `SECURE_SSL_REDIRECT = True` was returning 301 for all internal HTTP requests from Caddy and Docker health checks, making the site completely unreachable
- Added `SECURE_PROXY_SSL_HEADER` so Django trusts the `X-Forwarded-Proto: https` header from Caddy
- Added `health_headers` to Caddyfile health check
- Updated Docker health check to include the `X-Forwarded-Proto` header

## Test plan
- [ ] Merge to main → deploy triggers
- [ ] Verify https://habitreward.org loads
- [ ] Verify health check logs show 200 instead of 301
- [ ] Verify Telegram bot webhook still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)