### PR TITLE
fix: add TELEGRAM_BOT_USERNAME to deploy env

### DIFF
--- a/.github/workflows/deploy-caddy.yml
+++ b/.github/workflows/deploy-caddy.yml
@@ -145,6 +145,7 @@ jobs:
 
           # Telegram Bot
           TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_BOT_USERNAME=${{ secrets.TELEGRAM_BOT_USERNAME }}
           TELEGRAM_WEBHOOK_URL=${{ secrets.TELEGRAM_WEBHOOK_URL }}
 
           # Superuser (created on first run if not exists)


### PR DESCRIPTION
## Summary
- Missing `TELEGRAM_BOT_USERNAME` env var in the deploy workflow's `.env` template caused the login page to show "Telegram bot not configured" instead of the Telegram Login Widget

## Test plan
- [ ] Merge to main → deploy triggers
- [ ] Verify Telegram Login Widget appears on https://habitreward.org/auth/login/

🤖 Generated with [Claude Code](https://claude.com/claude-code)