### PR TITLE
fix: pass TELEGRAM_BOT_USERNAME to Docker container

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -20,6 +20,7 @@ services:
 
       # Telegram Bot Configuration
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
+      TELEGRAM_BOT_USERNAME: ${TELEGRAM_BOT_USERNAME:-}
       TELEGRAM_WEBHOOK_URL: ${TELEGRAM_WEBHOOK_URL:-https://habitreward.org/webhook/telegram}
 
       # Optional: Django Superuser (created on first run)


### PR DESCRIPTION
## Summary
- `TELEGRAM_BOT_USERNAME` was added to the `.env` file (PR #20) but docker-compose's `environment` section didn't include it, so the variable never reached the Django container — causing "Telegram bot not configured" on the login page

## Test plan
- [ ] Merge to main → deploy triggers
- [ ] Verify Telegram Login Widget appears on https://habitreward.org/auth/login/

🤖 Generated with [Claude Code](https://claude.com/claude-code)