### PR TITLE
fix: add unsafe-eval to CSP for Telegram widget

### DIFF
--- a/src/web/middleware.py
+++ b/src/web/middleware.py
@@ -62,11 +62,14 @@ class ContentSecurityPolicyMiddleware:
     and component-scoped styles often rely on inline styles. Alternatives
     (nonces or hashes) would require build/template changes; documented here
     for future hardening.
+
+    script-src includes 'unsafe-eval' because the Telegram Login Widget
+    (telegram-widget.js) uses eval() internally for __parseFunction.
     """
 
     CSP_POLICY = "; ".join([
         "default-src 'self'",
-        "script-src 'self' https://telegram.org",
+        "script-src 'self' 'unsafe-eval' https://telegram.org",
         "style-src 'self' 'unsafe-inline'",
         "img-src 'self' data: https:",
         "frame-src https://oauth.telegram.org",


### PR DESCRIPTION
## Summary
- Telegram's `telegram-widget.js` uses `eval()` internally (`__parseFunction`), which was blocked by our CSP `script-src` directive
- Added `'unsafe-eval'` to `script-src` in the CSP middleware

## Test plan
- [ ] Merge to main → deploy triggers
- [ ] Verify Telegram Login Widget button appears on https://habitreward.org/auth/login/
- [ ] Verify login flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)