### PR TITLE
feat: add web analytics page with completion rates, rankings, and tre…

### DIFF
--- a/docs/features/0042_PLAN.md
+++ b/docs/features/0042_PLAN.md
@@ -1,0 +1,158 @@
+# Feature 0042: Web Analytics Page
+
+## Description
+
+Add a new `/analytics/` web page that visualizes habit performance metrics using the existing analytics service. The page displays four sections: overall summary stats, completion rate bars, rankings table, and a daily/weekly trend chart (Chart.js). Users select a time period via 7d/30d/90d toggle buttons. Data is fetched server-side via Inertia props, consistent with all other pages.
+
+Navigation position: after Rewards, before Theme. Icon: 📊.
+
+---
+
+## Files to Create
+
+### `src/web/views/analytics.py`
+Django view serving the analytics page.
+
+- **`analytics_page(request)`** — async view, accepts `?period=7d|30d|90d` query param (default `30d`)
+  - Resolves date range using `get_user_today()` and period offset (same logic as `_resolve_date_range` in `src/api/v1/routers/analytics.py`, periods: 7d→6, 30d→29, 90d→89)
+  - Calls `analytics_service.get_habit_completion_rates(user.id, start, end)`
+  - Calls `analytics_service.get_habit_rankings(user.id, start, end, user_timezone=tz)`
+  - Calls `analytics_service.get_habit_trends(user.id, start, end)` (aggregate, no habit_id filter)
+  - Computes summary stats from the rates data:
+    - `avgCompletionRate`: mean of all habit completion rates
+    - `totalCompletions`: sum of `completed_days` across all habits
+    - `bestHabit`: habit with highest completion rate (name + rate)
+    - `totalAvailableDays`: sum of `available_days` across all habits
+  - Returns `inertia_render(request, "Analytics", props={...})` with:
+    - `rates`: list of `{habit_id, habit_name, completion_rate, completed_days, available_days}`
+    - `rankings`: list of `{rank, habit_id, habit_name, completion_rate, total_completions, current_streak, longest_streak_in_range}`
+    - `trends`: `{daily: [{date, completions}], weekly: [{week_start, completions, available_days, rate}]}`
+    - `summary`: `{avgCompletionRate, totalCompletions, bestHabit: {name, rate}, totalAvailableDays}`
+    - `currentPeriod`: the active period string ("7d", "30d", "90d")
+
+### `frontend/src/pages/Analytics.vue`
+Vue 3 SFC with four sections:
+
+**Props:** `rates`, `rankings`, `trends`, `summary`, `currentPeriod`
+
+**Period selector:** Three pill buttons (7d / 30d / 90d) at the top. Active button uses `tc.button.primary`, inactive uses `tc.button.secondary`. Clicking triggers `router.get('/analytics/', { period: '7d' }, { preserveScroll: true })`.
+
+**Section 1 — Summary cards:** Grid of 3-4 stat cards (like Streaks.vue pattern):
+- Average completion rate (as percentage)
+- Total completions in period
+- Best habit name + rate
+- Total available days
+
+**Section 2 — Completion rates:** Per-habit horizontal progress bars:
+- Each bar shows habit name, rate percentage, and a filled bar (width = `completion_rate * 100%`)
+- Bar color uses `var(--color-accent)`
+- Below each bar: "X of Y days" caption
+- Sorted by rate descending (already sorted from service)
+
+**Section 3 — Rankings table:** Card-based list (not HTML table, for theme consistency):
+- Each row: rank badge, habit name, completion rate %, streak 🔥, longest streak, total completions
+- Use `tc.card.*` classes for each row card
+- Apply `getCardEntranceStyle(idx)` for staggered animation
+
+**Section 4 — Trend chart:** Chart.js bar chart showing weekly completion rates:
+- X-axis: week start dates (formatted as "Mar 3", "Mar 10", etc.)
+- Y-axis: completion rate (0-100%)
+- Bar color: `var(--color-accent)`
+- Use `weekly` data from trends (not daily — weekly is less noisy)
+- Chart container wrapped in a themed card
+- Chart.js must read CSS variable colors at render time for theme compatibility
+
+**Theme integration:**
+- `useTheme()` for `themeConfig` and `tc` (classes)
+- `useThemeAnimation()` for `getCardEntranceStyle` and `hoverClass`
+- Respect `pageLayout.density` for spacing
+
+**Empty state:** If no habits/data, show centered message: "No analytics data available. Complete some habits to see your stats!"
+
+---
+
+## Files to Modify
+
+### `src/web/urls.py`
+- Import `analytics_page` from `src.web.views.analytics`
+- Add route: `path("analytics/", analytics_page, name="web_analytics")`
+
+### `frontend/src/components/Layout.vue`
+- Add nav item after Rewards: `{ href: "/analytics/", icon: "📊", label: "Analytics" }`
+
+---
+
+## Dependencies to Install
+
+### `chart.js` + `vue-chartjs`
+```bash
+cd frontend && npm install chart.js vue-chartjs
+```
+- `chart.js`: core charting library (~60KB gzipped)
+- `vue-chartjs`: Vue 3 wrapper providing `<Bar>`, `<Line>` etc. as Vue components
+
+Usage pattern in Analytics.vue:
+```javascript
+import { Bar } from 'vue-chartjs'
+import { Chart, BarElement, CategoryScale, LinearScale, Tooltip } from 'chart.js'
+Chart.register(BarElement, CategoryScale, LinearScale, Tooltip)
+```
+
+---
+
+## Algorithm Details
+
+### Period resolution (view)
+```
+period_offsets = {"7d": 6, "30d": 29, "90d": 89}
+today = get_user_today(user.timezone or "UTC")
+offset = period_offsets.get(period, 29)
+start_date = today - timedelta(days=offset)
+end_date = today
+```
+
+### Summary computation (view)
+```
+rates = [list of HabitCompletionRate from service]
+avg_rate = sum(r.completion_rate for r in rates) / len(rates) if rates else 0
+total_completions = sum(r.completed_days for r in rates)
+total_available = sum(r.available_days for r in rates)
+best = max(rates, key=lambda r: r.completion_rate) if rates else None
+```
+
+### Chart color extraction (frontend)
+```javascript
+const accentColor = computed(() =>
+  getComputedStyle(document.documentElement).getPropertyValue('--color-accent').trim()
+)
+```
+Must be reactive — recalculate when theme changes.
+
+---
+
+## Unit Tests
+
+### `tests/web/test_analytics_views.py`
+
+**Test scenarios:**
+
+1. **`test_analytics_page_default_period`** — GET `/analytics/` returns 200, props contain `rates`, `rankings`, `trends`, `summary`, `currentPeriod="30d"`
+2. **`test_analytics_page_7d_period`** — GET `/analytics/?period=7d` returns `currentPeriod="7d"`, verify service called with correct 7-day date range
+3. **`test_analytics_page_90d_period`** — same for 90d
+4. **`test_analytics_page_invalid_period_defaults_30d`** — GET `/analytics/?period=invalid` falls back to 30d
+5. **`test_analytics_page_no_habits`** — user with no habits returns empty rates/rankings, zero summary stats
+6. **`test_analytics_page_requires_auth`** — unauthenticated request redirects to login
+7. **`test_summary_computation`** — verify `avgCompletionRate` and `bestHabit` are computed correctly from mock rates data
+
+**Mocking pattern:** Patch `analytics_service` at the module level (`@patch("src.web.views.analytics.analytics_service")`), similar to `tests/api/test_analytics.py`.
+
+### `frontend/tests/analytics.spec.js`
+
+**Test scenarios:**
+
+1. **`renders summary cards with correct values`** — mount with mock props, verify summary stats are displayed
+2. **`renders completion rate bars`** — verify bars exist for each habit, widths match rates
+3. **`renders rankings list`** — verify rank numbers, habit names, streak values
+4. **`period buttons highlight active period`** — verify correct button has primary styling
+5. **`empty state shown when no data`** — mount with empty arrays, verify empty state message
+6. **`clicking period button triggers navigation`** — verify `router.get` called with correct period param

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,7 +7,9 @@
       "name": "habit-reward-frontend",
       "dependencies": {
         "@inertiajs/vue3": "^2.0.0",
-        "vue": "^3.5.0"
+        "chart.js": "^4.5.1",
+        "vue": "^3.5.0",
+        "vue-chartjs": "^5.3.3"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
@@ -732,6 +734,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
@@ -1807,6 +1815,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -3829,6 +3850,16 @@
         }
       }
     },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
+      "integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
+      }
+    },
     "node_modules/vue-component-type-helpers": {
       "version": "2.2.12",
       "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
@@ -3871,17 +3902,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/whatwg-url": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,16 +9,18 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@inertiajs/vue3": "^2.0.0",
+    "chart.js": "^4.5.1",
     "vue": "^3.5.0",
-    "@inertiajs/vue3": "^2.0.0"
+    "vue-chartjs": "^5.3.3"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-vue": "^5.0.0",
     "@vue/test-utils": "^2.4.0",
     "jsdom": "^26.0.0",
-    "vite": "^6.0.0",
-    "vitest": "^3.0.0",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/vite": "^4.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/frontend/src/components/Layout.vue
+++ b/frontend/src/components/Layout.vue
@@ -112,6 +112,7 @@ const navItems = [
   { href: "/streaks/", icon: "🔥", label: "Streaks" },
   { href: "/history/", icon: "📅", label: "History" },
   { href: "/rewards/", icon: "🎁", label: "Rewards" },
+  { href: "/analytics/", icon: "📊", label: "Analytics" },
   { href: "/theme/", icon: "🎨", label: "Theme" },
 ];
 

--- a/frontend/src/pages/Analytics.vue
+++ b/frontend/src/pages/Analytics.vue
@@ -167,16 +167,22 @@ const textSecondaryColor = ref(readCssVar("--color-text-secondary"));
 watch(
   () => themeConfig.value,
   () => {
+    // Double-rAF ensures CSS vars are applied before reading — useTheme applies
+    // vars in its own rAF, so we need to wait one more frame.
     requestAnimationFrame(() => {
-      accentColor.value = readCssVar("--color-accent");
-      textSecondaryColor.value = readCssVar("--color-text-secondary");
+      requestAnimationFrame(() => {
+        accentColor.value = readCssVar("--color-accent");
+        textSecondaryColor.value = readCssVar("--color-text-secondary");
+      });
     });
   },
 );
 
 function formatWeekLabel(dateStr) {
-  const d = new Date(dateStr + "T00:00:00");
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  // Parse YYYY-MM-DD without Date constructor to avoid timezone shifts
+  const [, m, d] = dateStr.split("-").map(Number);
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${months[m - 1]} ${d}`;
 }
 
 const chartData = computed(() => ({

--- a/frontend/src/pages/Analytics.vue
+++ b/frontend/src/pages/Analytics.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="px-4 pt-6 pb-4 max-w-2xl mx-auto">
     <!-- Period selector -->
-    <div class="flex gap-2 mb-6" :style="getCardEntranceStyle(0)">
+    <div class="flex gap-2 mb-6" role="group" aria-label="Time period" :style="getCardEntranceStyle(0)">
       <button
         v-for="p in periods"
         :key="p"
         @click="switchPeriod(p)"
+        :aria-label="`Show analytics for ${p}`"
+        :aria-pressed="p === currentPeriod"
         class="px-4 py-1.5 text-sm font-medium rounded-full transition-colors"
         :class="p === currentPeriod ? tc.button.primary : tc.button.secondary"
       >

--- a/frontend/src/pages/Analytics.vue
+++ b/frontend/src/pages/Analytics.vue
@@ -1,0 +1,222 @@
+<template>
+  <div class="px-4 pt-6 pb-4 max-w-2xl mx-auto">
+    <!-- Period selector -->
+    <div class="flex gap-2 mb-6" :style="getCardEntranceStyle(0)">
+      <button
+        v-for="p in periods"
+        :key="p"
+        @click="switchPeriod(p)"
+        class="px-4 py-1.5 text-sm font-medium rounded-full transition-colors"
+        :class="p === currentPeriod ? tc.button.primary : tc.button.secondary"
+      >
+        {{ p }}
+      </button>
+    </div>
+
+    <!-- Empty state -->
+    <div v-if="rates.length === 0" class="text-center py-12">
+      <p class="text-text-secondary">No analytics data available. Complete some habits to see your stats!</p>
+    </div>
+
+    <template v-else>
+      <!-- Section 1: Summary cards -->
+      <div
+        class="p-4 mb-6"
+        :class="[tc.card.rounded, tc.card.shadow, tc.card.border, tc.card.bg, tc.card.extra]"
+        :style="getCardEntranceStyle(1)"
+      >
+        <h1 class="text-2xl font-bold text-text-primary mb-3">Analytics</h1>
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
+          <div>
+            <p class="text-2xl font-bold text-accent">{{ formatPercent(summary.avgCompletionRate) }}</p>
+            <p class="text-xs text-text-secondary">Avg completion</p>
+          </div>
+          <div>
+            <p class="text-2xl font-bold text-text-primary">{{ summary.totalCompletions }}</p>
+            <p class="text-xs text-text-secondary">Total completions</p>
+          </div>
+          <div>
+            <p class="text-2xl font-bold text-accent truncate" :title="summary.bestHabit?.name">
+              {{ summary.bestHabit?.name || 'N/A' }}
+            </p>
+            <p class="text-xs text-text-secondary">
+              Best habit {{ summary.bestHabit ? `(${formatPercent(summary.bestHabit.rate)})` : '' }}
+            </p>
+          </div>
+          <div>
+            <p class="text-2xl font-bold text-text-primary">{{ summary.totalAvailableDays }}</p>
+            <p class="text-xs text-text-secondary">Available days</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Section 2: Completion rate bars -->
+      <div
+        class="p-4 mb-6"
+        :class="[tc.card.rounded, tc.card.shadow, tc.card.border, tc.card.bg, tc.card.extra]"
+        :style="getCardEntranceStyle(2)"
+      >
+        <h2 class="text-lg font-semibold text-text-primary mb-3">Completion Rates</h2>
+        <div class="space-y-3">
+          <div v-for="rate in rates" :key="rate.habit_id">
+            <div class="flex justify-between items-center mb-1">
+              <span class="text-sm font-medium text-text-primary truncate">{{ rate.habit_name }}</span>
+              <span class="text-sm font-semibold text-accent ml-2 shrink-0">{{ formatPercent(rate.completion_rate) }}</span>
+            </div>
+            <div class="w-full h-2 rounded-full bg-bg-card-hover">
+              <div
+                class="h-2 rounded-full bg-accent transition-all duration-500"
+                :style="{ width: `${(rate.completion_rate * 100).toFixed(0)}%` }"
+              />
+            </div>
+            <p class="text-xs text-text-secondary mt-0.5">{{ rate.completed_days }} of {{ rate.available_days }} days</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Section 3: Rankings -->
+      <div class="space-y-2 mb-6">
+        <h2
+          class="text-lg font-semibold text-text-primary"
+          :style="getCardEntranceStyle(3)"
+        >Rankings</h2>
+        <div
+          v-for="(r, idx) in rankings"
+          :key="r.habit_id"
+          class="p-3 flex items-center gap-3"
+          :class="[tc.card.rounded, tc.card.shadow, tc.card.border, tc.card.bg, tc.card.extra, hoverClass]"
+          :style="getCardEntranceStyle(4 + idx)"
+        >
+          <span class="text-lg font-bold text-accent w-8 text-center shrink-0">#{{ r.rank }}</span>
+          <div class="flex-1 min-w-0">
+            <p class="font-medium text-text-primary truncate">{{ r.habit_name }}</p>
+            <div class="flex items-center gap-3 mt-0.5 text-xs text-text-secondary">
+              <span>{{ formatPercent(r.completion_rate) }}</span>
+              <span>🔥 {{ r.current_streak }}</span>
+              <span>Best: {{ r.longest_streak_in_range }}</span>
+              <span>{{ r.total_completions }} done</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Section 4: Trend chart -->
+      <div
+        class="p-4"
+        :class="[tc.card.rounded, tc.card.shadow, tc.card.border, tc.card.bg, tc.card.extra]"
+        :style="getCardEntranceStyle(4 + rankings.length)"
+      >
+        <h2 class="text-lg font-semibold text-text-primary mb-3">Weekly Trends</h2>
+        <div v-if="trends.weekly.length > 0" class="h-64">
+          <Bar :data="chartData" :options="chartOptions" />
+        </div>
+        <p v-else class="text-sm text-text-secondary text-center py-8">Not enough data for trends yet.</p>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed, watch, ref } from "vue";
+import { router } from "@inertiajs/vue3";
+import { Bar } from "vue-chartjs";
+import { Chart, BarElement, CategoryScale, LinearScale, Tooltip } from "chart.js";
+import { useTheme } from "../composables/useTheme.js";
+import { useThemeAnimation } from "../composables/useThemeAnimation.js";
+
+Chart.register(BarElement, CategoryScale, LinearScale, Tooltip);
+
+const props = defineProps({
+  rates: { type: Array, default: () => [] },
+  rankings: { type: Array, default: () => [] },
+  trends: { type: Object, default: () => ({ daily: [], weekly: [] }) },
+  summary: {
+    type: Object,
+    default: () => ({
+      avgCompletionRate: 0,
+      totalCompletions: 0,
+      bestHabit: null,
+      totalAvailableDays: 0,
+    }),
+  },
+  currentPeriod: { type: String, default: "30d" },
+});
+
+const periods = ["7d", "30d", "90d"];
+
+const { themeConfig } = useTheme();
+const tc = computed(() => themeConfig.value.classes);
+const { getCardEntranceStyle, hoverClass } = useThemeAnimation();
+
+function switchPeriod(p) {
+  router.get("/analytics/", { period: p }, { preserveScroll: true });
+}
+
+function formatPercent(rate) {
+  return `${(rate * 100).toFixed(0)}%`;
+}
+
+// Chart.js reads CSS colors reactively for theme compatibility
+function readCssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+const accentColor = ref(readCssVar("--color-accent"));
+const textSecondaryColor = ref(readCssVar("--color-text-secondary"));
+
+watch(
+  () => themeConfig.value,
+  () => {
+    requestAnimationFrame(() => {
+      accentColor.value = readCssVar("--color-accent");
+      textSecondaryColor.value = readCssVar("--color-text-secondary");
+    });
+  },
+);
+
+function formatWeekLabel(dateStr) {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+const chartData = computed(() => ({
+  labels: props.trends.weekly.map((w) => formatWeekLabel(w.week_start)),
+  datasets: [
+    {
+      label: "Completion Rate",
+      data: props.trends.weekly.map((w) => +(w.rate * 100).toFixed(1)),
+      backgroundColor: accentColor.value || "#6366f1",
+      borderRadius: 4,
+    },
+  ],
+}));
+
+const chartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    tooltip: {
+      callbacks: {
+        label: (ctx) => `${ctx.parsed.y}%`,
+      },
+    },
+  },
+  scales: {
+    y: {
+      min: 0,
+      max: 100,
+      ticks: {
+        callback: (v) => `${v}%`,
+        color: textSecondaryColor.value,
+      },
+      grid: { color: "rgba(128,128,128,0.1)" },
+    },
+    x: {
+      ticks: {
+        color: textSecondaryColor.value,
+      },
+      grid: { display: false },
+    },
+  },
+}));
+</script>

--- a/frontend/src/pages/Analytics.vue
+++ b/frontend/src/pages/Analytics.vue
@@ -117,7 +117,7 @@
 </template>
 
 <script setup>
-import { computed, watch, ref } from "vue";
+import { computed } from "vue";
 import { router } from "@inertiajs/vue3";
 import { Bar } from "vue-chartjs";
 import { Chart, BarElement, CategoryScale, LinearScale, Tooltip } from "chart.js";
@@ -156,31 +156,13 @@ function formatPercent(rate) {
   return `${(rate * 100).toFixed(0)}%`;
 }
 
-// Chart.js reads CSS colors reactively for theme compatibility
-function readCssVar(name) {
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-}
-
-const accentColor = ref(readCssVar("--color-accent"));
-const textSecondaryColor = ref(readCssVar("--color-text-secondary"));
-
-watch(
-  () => themeConfig.value,
-  () => {
-    // Double-rAF ensures CSS vars are applied before reading — useTheme applies
-    // vars in its own rAF, so we need to wait one more frame.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        accentColor.value = readCssVar("--color-accent");
-        textSecondaryColor.value = readCssVar("--color-text-secondary");
-      });
-    });
-  },
-);
+// Read chart colors directly from theme config — no DOM reads or timing hacks needed
+const accentColor = computed(() => themeConfig.value.cssVars["--color-accent"]);
+const textSecondaryColor = computed(() => themeConfig.value.cssVars["--color-text-secondary"]);
 
 function formatWeekLabel(dateStr) {
   // Parse YYYY-MM-DD without Date constructor to avoid timezone shifts
-  const [, m, d] = dateStr.split("-").map(Number);
+  const [_year, m, d] = dateStr.split("-").map(Number);
   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
   return `${months[m - 1]} ${d}`;
 }
@@ -191,7 +173,7 @@ const chartData = computed(() => ({
     {
       label: "Completion Rate",
       data: props.trends.weekly.map((w) => +(w.rate * 100).toFixed(1)),
-      backgroundColor: accentColor.value || "#6366f1",
+      backgroundColor: accentColor.value,
       borderRadius: 4,
     },
   ],

--- a/frontend/tests/analytics.spec.js
+++ b/frontend/tests/analytics.spec.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import Analytics from "../src/pages/Analytics.vue";
+
+// Mock Chart.js and vue-chartjs
+vi.mock("vue-chartjs", () => ({
+  Bar: { template: '<canvas data-testid="chart" />', props: ["data", "options"] },
+}));
+vi.mock("chart.js", () => ({
+  Chart: { register: vi.fn() },
+  BarElement: {},
+  CategoryScale: {},
+  LinearScale: {},
+  Tooltip: {},
+}));
+
+// Mock Inertia router
+const { mockRouterGet } = vi.hoisted(() => ({
+  mockRouterGet: vi.fn(),
+}));
+vi.mock("@inertiajs/vue3", () => ({
+  router: { get: mockRouterGet },
+}));
+
+// Mock composables
+vi.mock("../src/composables/useTheme.js", () => ({
+  useTheme: () => ({
+    themeConfig: {
+      value: {
+        classes: {
+          card: { rounded: "rounded", shadow: "shadow", border: "border", bg: "bg", extra: "" },
+          button: { primary: "btn-primary", secondary: "btn-secondary" },
+          select: { base: "select-base" },
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock("../src/composables/useThemeAnimation.js", () => ({
+  useThemeAnimation: () => ({
+    getCardEntranceStyle: () => ({}),
+    hoverClass: "hover-class",
+  }),
+}));
+
+const baseProps = {
+  rates: [
+    { habit_id: 1, habit_name: "Running", completion_rate: 0.8, completed_days: 24, available_days: 30 },
+    { habit_id: 2, habit_name: "Reading", completion_rate: 0.6, completed_days: 18, available_days: 30 },
+  ],
+  rankings: [
+    { rank: 1, habit_id: 1, habit_name: "Running", completion_rate: 0.8, total_completions: 24, current_streak: 5, longest_streak_in_range: 10 },
+    { rank: 2, habit_id: 2, habit_name: "Reading", completion_rate: 0.6, total_completions: 18, current_streak: 3, longest_streak_in_range: 7 },
+  ],
+  trends: {
+    daily: [{ date: "2026-03-01", completions: 2 }],
+    weekly: [{ week_start: "2026-02-23", completions: 10, available_days: 14, rate: 0.71 }],
+  },
+  summary: {
+    avgCompletionRate: 0.7,
+    totalCompletions: 42,
+    bestHabit: { name: "Running", rate: 0.8 },
+    totalAvailableDays: 60,
+  },
+  currentPeriod: "30d",
+};
+
+describe("Analytics page", () => {
+  beforeEach(() => {
+    mockRouterGet.mockClear();
+  });
+
+  it("renders summary cards with correct values", () => {
+    const wrapper = mount(Analytics, { props: baseProps });
+    const text = wrapper.text();
+    expect(text).toContain("70%");
+    expect(text).toContain("42");
+    expect(text).toContain("Running");
+    expect(text).toContain("60");
+  });
+
+  it("renders completion rate bars", () => {
+    const wrapper = mount(Analytics, { props: baseProps });
+    const text = wrapper.text();
+    expect(text).toContain("Running");
+    expect(text).toContain("80%");
+    expect(text).toContain("24 of 30 days");
+    expect(text).toContain("Reading");
+    expect(text).toContain("60%");
+    expect(text).toContain("18 of 30 days");
+  });
+
+  it("renders rankings list", () => {
+    const wrapper = mount(Analytics, { props: baseProps });
+    const text = wrapper.text();
+    expect(text).toContain("#1");
+    expect(text).toContain("#2");
+    expect(text).toContain("🔥 5");
+    expect(text).toContain("Best: 10");
+  });
+
+  it("period buttons highlight active period", () => {
+    const wrapper = mount(Analytics, { props: baseProps });
+    const buttons = wrapper.findAll("button");
+    const btn30d = buttons.find((b) => b.text() === "30d");
+    const btn7d = buttons.find((b) => b.text() === "7d");
+    expect(btn30d.classes()).toContain("btn-primary");
+    expect(btn7d.classes()).toContain("btn-secondary");
+  });
+
+  it("empty state shown when no data", () => {
+    const wrapper = mount(Analytics, {
+      props: {
+        ...baseProps,
+        rates: [],
+        rankings: [],
+        trends: { daily: [], weekly: [] },
+        summary: { avgCompletionRate: 0, totalCompletions: 0, bestHabit: null, totalAvailableDays: 0 },
+      },
+    });
+    expect(wrapper.text()).toContain("No analytics data available");
+  });
+
+  it("clicking period button triggers navigation", async () => {
+    const wrapper = mount(Analytics, { props: baseProps });
+    const btn7d = wrapper.findAll("button").find((b) => b.text() === "7d");
+    await btn7d.trigger("click");
+    expect(mockRouterGet).toHaveBeenCalledWith("/analytics/", { period: "7d" }, { preserveScroll: true });
+  });
+});

--- a/frontend/tests/analytics.spec.js
+++ b/frontend/tests/analytics.spec.js
@@ -32,6 +32,10 @@ vi.mock("../src/composables/useTheme.js", () => ({
           button: { primary: "btn-primary", secondary: "btn-secondary" },
           select: { base: "select-base" },
         },
+        cssVars: {
+          "--color-accent": "#6366f1",
+          "--color-text-secondary": "#9ca3af",
+        },
       },
     },
   }),

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -2,6 +2,7 @@
 
 from django.urls import path
 
+from src.web.views.analytics import analytics_page
 from src.web.views.dashboard import complete_habit, dashboard, revert_habit
 from src.web.views.history import history_page
 from src.web.views.rewards import claim_reward, rewards_page
@@ -13,6 +14,7 @@ urlpatterns = [
     path("streaks/", streaks_page, name="web_streaks"),
     path("history/", history_page, name="web_history"),
     path("rewards/", rewards_page, name="web_rewards"),
+    path("analytics/", analytics_page, name="web_analytics"),
     path("theme/", theme_page, name="web_theme"),
     path("theme/save/", save_theme, name="web_save_theme"),
     path("habits/<int:habit_id>/complete/", complete_habit, name="web_complete_habit"),

--- a/src/web/views/analytics.py
+++ b/src/web/views/analytics.py
@@ -4,6 +4,8 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from django.contrib import messages
+from django.shortcuts import redirect
 from inertia import render as inertia_render
 
 from src.bot.timezone_utils import get_user_today
@@ -30,11 +32,16 @@ async def analytics_page(request):
     start_date = today - timedelta(days=offset)
     end_date = today
 
-    rates, rankings, trends = await asyncio.gather(
-        maybe_await(analytics_service.get_habit_completion_rates(user.id, start_date, end_date)),
-        maybe_await(analytics_service.get_habit_rankings(user.id, start_date, end_date, user_timezone=tz)),
-        maybe_await(analytics_service.get_habit_trends(user.id, start_date, end_date)),
-    )
+    try:
+        rates, rankings, trends = await asyncio.gather(
+            maybe_await(analytics_service.get_habit_completion_rates(user.id, start_date, end_date)),
+            maybe_await(analytics_service.get_habit_rankings(user.id, start_date, end_date, user_timezone=tz)),
+            maybe_await(analytics_service.get_habit_trends(user.id, start_date, end_date)),
+        )
+    except Exception:
+        logger.exception("Failed to load analytics for user %s", user.id)
+        messages.error(request, "Failed to load analytics. Please try again.")
+        return redirect("/")
 
     # Compute summary stats
     if rates:

--- a/src/web/views/analytics.py
+++ b/src/web/views/analytics.py
@@ -1,0 +1,71 @@
+"""Analytics page view."""
+
+import logging
+from datetime import timedelta
+
+from inertia import render as inertia_render
+
+from src.bot.timezone_utils import get_user_today
+from src.services.analytics_service import analytics_service
+from src.utils.async_compat import maybe_await
+
+logger = logging.getLogger(__name__)
+
+PERIOD_OFFSETS = {"7d": 6, "30d": 29, "90d": 89}
+VALID_PERIODS = set(PERIOD_OFFSETS.keys())
+
+
+async def analytics_page(request):
+    """Habit performance analytics page."""
+    user = request.user
+    tz = user.timezone or "UTC"
+    today = get_user_today(tz)
+
+    period = request.GET.get("period", "30d")
+    if period not in VALID_PERIODS:
+        period = "30d"
+
+    offset = PERIOD_OFFSETS[period]
+    start_date = today - timedelta(days=offset)
+    end_date = today
+
+    rates = await maybe_await(analytics_service.get_habit_completion_rates(user.id, start_date, end_date))
+    rankings = await maybe_await(analytics_service.get_habit_rankings(user.id, start_date, end_date, user_timezone=tz))
+    trends = await maybe_await(analytics_service.get_habit_trends(user.id, start_date, end_date))
+
+    # Compute summary stats
+    if rates:
+        avg_rate = sum(r.completion_rate for r in rates) / len(rates)
+        total_completions = sum(r.completed_days for r in rates)
+        total_available = sum(r.available_days for r in rates)
+        best = max(rates, key=lambda r: r.completion_rate)
+        best_habit = {"name": best.habit_name, "rate": best.completion_rate}
+    else:
+        avg_rate = 0
+        total_completions = 0
+        total_available = 0
+        best_habit = None
+
+    return inertia_render(request, "Analytics", props={
+        "rates": [r.model_dump() for r in rates],
+        "rankings": [r.model_dump() for r in rankings],
+        "trends": {
+            "daily": [{"date": str(d.date), "completions": d.completions} for d in trends.daily],
+            "weekly": [
+                {
+                    "week_start": str(w.week_start),
+                    "completions": w.completions,
+                    "available_days": w.available_days,
+                    "rate": w.rate,
+                }
+                for w in trends.weekly
+            ],
+        },
+        "summary": {
+            "avgCompletionRate": avg_rate,
+            "totalCompletions": total_completions,
+            "bestHabit": best_habit,
+            "totalAvailableDays": total_available,
+        },
+        "currentPeriod": period,
+    })

--- a/src/web/views/analytics.py
+++ b/src/web/views/analytics.py
@@ -1,5 +1,6 @@
 """Analytics page view."""
 
+import asyncio
 import logging
 from datetime import timedelta
 
@@ -29,9 +30,11 @@ async def analytics_page(request):
     start_date = today - timedelta(days=offset)
     end_date = today
 
-    rates = await maybe_await(analytics_service.get_habit_completion_rates(user.id, start_date, end_date))
-    rankings = await maybe_await(analytics_service.get_habit_rankings(user.id, start_date, end_date, user_timezone=tz))
-    trends = await maybe_await(analytics_service.get_habit_trends(user.id, start_date, end_date))
+    rates, rankings, trends = await asyncio.gather(
+        maybe_await(analytics_service.get_habit_completion_rates(user.id, start_date, end_date)),
+        maybe_await(analytics_service.get_habit_rankings(user.id, start_date, end_date, user_timezone=tz)),
+        maybe_await(analytics_service.get_habit_trends(user.id, start_date, end_date)),
+    )
 
     # Compute summary stats
     if rates:

--- a/tests/web/test_analytics_views.py
+++ b/tests/web/test_analytics_views.py
@@ -1,0 +1,132 @@
+"""Tests for analytics page view."""
+
+from datetime import date
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.models.analytics import (
+    DailyCompletion,
+    HabitCompletionRate,
+    HabitRanking,
+    HabitTrendData,
+    WeeklySummary,
+)
+from tests.web.conftest import INERTIA_HEADERS, _inertia_props
+
+
+def _mock_rates():
+    return [
+        HabitCompletionRate(
+            habit_id=1, habit_name="Running", completion_rate=0.8,
+            completed_days=24, available_days=30,
+        ),
+        HabitCompletionRate(
+            habit_id=2, habit_name="Reading", completion_rate=0.6,
+            completed_days=18, available_days=30,
+        ),
+    ]
+
+
+def _mock_rankings():
+    return [
+        HabitRanking(
+            rank=1, habit_id=1, habit_name="Running", completion_rate=0.8,
+            total_completions=24, current_streak=5, longest_streak_in_range=10,
+        ),
+        HabitRanking(
+            rank=2, habit_id=2, habit_name="Reading", completion_rate=0.6,
+            total_completions=18, current_streak=3, longest_streak_in_range=7,
+        ),
+    ]
+
+
+def _mock_trends():
+    return HabitTrendData(
+        daily=[DailyCompletion(date=date(2026, 3, 1), completions=2)],
+        weekly=[WeeklySummary(week_start=date(2026, 2, 23), completions=10, available_days=14, rate=0.71)],
+    )
+
+
+def _patch_analytics():
+    return patch("src.web.views.analytics.analytics_service")
+
+
+@pytest.mark.django_db
+class TestAnalyticsPage:
+
+    def _setup_mocks(self, mock_svc, rates=None, rankings=None, trends=None):
+        mock_svc.get_habit_completion_rates = AsyncMock(return_value=_mock_rates() if rates is None else rates)
+        mock_svc.get_habit_rankings = AsyncMock(return_value=_mock_rankings() if rankings is None else rankings)
+        mock_svc.get_habit_trends = AsyncMock(return_value=_mock_trends() if trends is None else trends)
+
+    def test_analytics_page_default_period(self, auth_client):
+        with _patch_analytics() as mock_svc:
+            self._setup_mocks(mock_svc)
+            response = auth_client.get("/analytics/", **INERTIA_HEADERS)
+            assert response.status_code == 200
+            component, props = _inertia_props(response)
+            assert component == "Analytics"
+            assert props["currentPeriod"] == "30d"
+            assert "rates" in props
+            assert "rankings" in props
+            assert "trends" in props
+            assert "summary" in props
+
+    def test_analytics_page_7d_period(self, auth_client):
+        with _patch_analytics() as mock_svc:
+            self._setup_mocks(mock_svc)
+            response = auth_client.get("/analytics/?period=7d", **INERTIA_HEADERS)
+            assert response.status_code == 200
+            _, props = _inertia_props(response)
+            assert props["currentPeriod"] == "7d"
+
+    def test_analytics_page_90d_period(self, auth_client):
+        with _patch_analytics() as mock_svc:
+            self._setup_mocks(mock_svc)
+            response = auth_client.get("/analytics/?period=90d", **INERTIA_HEADERS)
+            assert response.status_code == 200
+            _, props = _inertia_props(response)
+            assert props["currentPeriod"] == "90d"
+
+    def test_analytics_page_invalid_period_defaults_30d(self, auth_client):
+        with _patch_analytics() as mock_svc:
+            self._setup_mocks(mock_svc)
+            response = auth_client.get("/analytics/?period=invalid", **INERTIA_HEADERS)
+            assert response.status_code == 200
+            _, props = _inertia_props(response)
+            assert props["currentPeriod"] == "30d"
+
+    def test_analytics_page_no_habits(self, auth_client):
+        with _patch_analytics() as mock_svc:
+            self._setup_mocks(
+                mock_svc,
+                rates=[],
+                rankings=[],
+                trends=HabitTrendData(daily=[], weekly=[]),
+            )
+            response = auth_client.get("/analytics/", **INERTIA_HEADERS)
+            assert response.status_code == 200
+            _, props = _inertia_props(response)
+            assert props["rates"] == []
+            assert props["rankings"] == []
+            assert props["summary"]["avgCompletionRate"] == 0
+            assert props["summary"]["totalCompletions"] == 0
+            assert props["summary"]["bestHabit"] is None
+
+    def test_analytics_page_requires_auth(self, client):
+        response = client.get("/analytics/")
+        assert response.status_code == 302
+
+    def test_summary_computation(self, auth_client):
+        with _patch_analytics() as mock_svc:
+            self._setup_mocks(mock_svc)
+            response = auth_client.get("/analytics/", **INERTIA_HEADERS)
+            _, props = _inertia_props(response)
+            summary = props["summary"]
+            # avg of 0.8 and 0.6 = 0.7
+            assert abs(summary["avgCompletionRate"] - 0.7) < 0.01
+            assert summary["totalCompletions"] == 42  # 24 + 18
+            assert summary["totalAvailableDays"] == 60  # 30 + 30
+            assert summary["bestHabit"]["name"] == "Running"
+            assert summary["bestHabit"]["rate"] == 0.8


### PR DESCRIPTION
…nd chart

New /analytics/ page visualizes habit performance metrics using the existing analytics service. Includes summary stats, per-habit completion rate bars, rankings list, and a Chart.js weekly trend chart with reactive theme colors. Period selector (7d/30d/90d) filters data server-side via Inertia props.