### PR TITLE
feat: reorder active rewards to show zero-piece first

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -102,17 +102,17 @@ This document tracks planned features, improvements, and enhancements for the Ha
 
 ## 📊 Analytics & Reporting
 
-- [ ] **User Analytics Dashboard**
+- [x] **User Analytics Dashboard**
   - Completion rates over time
   - Reward claim patterns
   - Streak analysis
-  - **File**: New `src/dashboard/analytics.py`
+  - **File**: `src/web/views/analytics.py`, `frontend/src/pages/Analytics.vue`
 
-- [ ] **Habit Performance Metrics**
+- [x] **Habit Performance Metrics**
   - Which habits are most/least completed
   - Average completion time
   - Drop-off rates
-  - **File**: New service `src/services/analytics_service.py`
+  - **File**: `src/services/analytics_service.py`
 
 - [ ] **Reward Effectiveness Analysis**
   - Which rewards motivate users most
@@ -171,6 +171,11 @@ This document tracks planned features, improvements, and enhancements for the Ha
   - Visual calendar showing completion history
   - Click to mark habits as done
   - **File**: `src/dashboard/components/calendar.py`
+
+- [x] **Change rewards sorting on Rewards page (web app)**
+  - **Now**: rewards with >1 won pieces, then claimed, then 0 won pieces
+  - **Need**: 0 won pieces first, then >1 won pieces (ascending by won pieces), then claimed last
+  - **File**: Rewards page (web)
 
 - [ ] **Reward Progress Visualization**
   - Progress bars, charts for reward progress

--- a/docs/features/0043_PLAN.md
+++ b/docs/features/0043_PLAN.md
@@ -1,0 +1,119 @@
+# Feature 0043: Rewards page sorting order
+
+## Description
+
+Change the sorting order on the web app Rewards page.
+
+- **Now**: rewards with >1 won pieces, claimed, 0 won pieces
+- **Need**: 0 won pieces, more than one (ascending), claimed
+
+In the current web UI, claimed rewards are already rendered in a separate collapsible section (`claimedRewards`) below the active rewards list (`rewards`). This plan updates the ordering of the active rewards list so it matches the “Need” order.
+
+---
+
+## Files to Modify
+
+### `src/services/reward_service.py`
+
+Update **`RewardService.get_user_reward_progress(user_id)`** to change ordering semantics.
+
+Current behavior (per docstring + implementation):
+- Builds three groups: `pending` (pieces > 0), `achieved`, `never_won` (0 pieces / unknown required)
+- Sorts pending by fill percentage descending
+- Returns `pending + achieved + never_won`
+- Excludes one-time claimed rewards from the list; treats recurring claimed rewards as “never-won” (fresh cycle)
+
+Required new behavior:
+- **Return 0-piece rewards first** (the “0 won pieces” group)
+- Then return **all non-claimed, non-zero** rewards sorted by **won pieces ascending**
+  - “won pieces” here maps to `RewardProgress.pieces_earned` (serialized to `piecesEarned` in `src/web/views/rewards.py`)
+  - Include both PENDING and ACHIEVED rewards in this non-zero group
+- **Claimed** items remain last by continuing to keep them out of the `rewards` list and in `claimedRewards` (handled by `src/web/views/rewards.py` via `reward_service.get_claimed_rewards`)
+
+Implementation notes (no code):
+- Keep existing filtering rules intact:
+  - One-time `CLAIMED`: excluded from `get_user_reward_progress()`
+  - Recurring `CLAIMED`: treated as 0-piece / fresh cycle
+  - `pieces_required is None` continues to be treated as “0 won pieces” for ordering purposes (matches existing bucketing into `never_won`)
+- Replace the “pending by fill percentage descending” sort with a deterministic key-based ordering:
+  - Partition into:
+    - `zero_piece`: `pieces_earned == 0` **or** `pieces_required is None`
+    - `non_zero`: everything else that is not claimed
+  - Sort `non_zero` by `pieces_earned` ascending
+  - Use stable tie-breakers to avoid flicker when equal `pieces_earned`:
+    - Secondary: fill percentage ascending (or required pieces ascending) if desired
+    - Final: reward name (requires `reward` to be present) or repository order (stable)
+
+### `src/web/views/rewards.py`
+
+No behavior change required if it already:
+- Builds `rewards` from `get_user_reward_progress()` results
+- Builds `claimedRewards` from `get_claimed_rewards()`
+
+If any additional sorting exists here (or is added later), ensure it does **not** reintroduce the old ordering.
+
+### `frontend/src/pages/Rewards.vue`
+
+No sorting logic expected here (it currently renders the `rewards` prop as provided). Verify it stays “dumb” and does not sort client-side.
+
+---
+
+## Algorithm Details
+
+### Active rewards ordering (server-side)
+
+Given the coerced `RewardProgress` list (with synthetic 0-piece entries added for active rewards without a progress row):
+
+1. **Filter / normalize**
+   - If status is `CLAIMED`:
+     - If recurring: treat as 0-piece group
+     - If one-time: exclude from active list
+2. **Partition into groups**
+   - `zero_piece`: \(pieces\_earned == 0\) OR \(pieces\_required is None\)
+   - `non_zero`: everything else (includes both PENDING and ACHIEVED)
+3. **Sort**
+   - `zero_piece`: keep stable (repo order) or alphabetical by reward name (choose one and test it)
+   - `non_zero`: sort by \(pieces\_earned\) ascending, with stable tie-breakers
+4. **Return**
+   - `zero_piece + non_zero`
+
+Claimed ordering:
+- Claimed rewards remain in `get_claimed_rewards()` and are rendered below active rewards in the UI, satisfying “claimed last”.
+
+---
+
+## Unit Tests
+
+### Update existing tests in `tests/test_reward_filtering.py`
+
+Adjust the “Ordering” section to match the new requirement:
+
+- Replace / update `test_sort_by_percentage_descending`
+  - New scenario: multiple non-zero rewards with different `pieces_earned`
+  - Assert ordering is ascending by `pieces_earned` (e.g., 1, 3, 7)
+
+- Replace / update `test_achieved_after_pending`
+  - New scenario: mix ACHIEVED and PENDING; ensure both participate in the same non-zero ordering bucket
+  - Example: achieved at 10 pieces should appear after pending at 5 pieces (because 5 < 10)
+
+- Replace / update `test_never_won_at_bottom`
+  - New assertion: rewards with 0 pieces earned appear **first**
+
+- Update `test_mixed_ordering_all_groups`
+  - Ensure:
+    - 0-piece entries come first
+    - claimed one-time entries are excluded from active list
+    - non-zero entries are ascending by `pieces_earned`
+
+### Add regression tests (same file)
+
+- **Synthetic active reward with no progress row**
+  - When `reward_repo.get_all_active()` returns an active reward missing from progress, it is synthesized as 0-piece and must appear in the `zero_piece` group at the top.
+
+- **`pieces_required is None`**
+  - Verify it is treated as `zero_piece` and appears in the 0-piece group.
+
+### Async parity (if needed)
+
+If `tests/services/test_reward_service_async.py` or other async-focused tests assert ordering, update them to match the new sort rule.
+

--- a/docs/features/0043_REVIEW.md
+++ b/docs/features/0043_REVIEW.md
@@ -1,0 +1,164 @@
+# Feature 0043 — Code Review
+
+## Summary
+
+The plan was implemented faithfully. Active rewards are now returned in the new order (`zero_piece` first, then `non_zero` ascending by `pieces_earned`), claimed one-time rewards remain excluded from the active list, and claimed items continue to be rendered as a separate collapsible section in the Vue page. The unit tests were updated to match the new semantics and a new regression test was added for synthetic active-reward rows. All 17 tests in `tests/test_reward_filtering.py` pass.
+
+Verdict: ship-ready, with a couple of small observations to consider.
+
+---
+
+## 1. Plan fidelity
+
+All plan requirements are met:
+
+- Partitioning matches the plan's `zero_piece` vs `non_zero` split (`src/services/reward_service.py` lines 569–586).
+
+```569:586:src/services/reward_service.py
+            zero_piece: list[RewardProgress] = []
+            non_zero: list[RewardProgress] = []
+            for p in coerced:
+                progress_reward_ids.add(
+                    int(p.reward_id) if isinstance(p.reward_id, str) else p.reward_id
+                )
+                status = p.get_status()
+                if status == RewardStatus.CLAIMED:
+                    reward_obj = getattr(p, "reward", None)
+                    if reward_obj and getattr(reward_obj, "is_recurring", False):
+                        zero_piece.append(p)
+                    continue
+
+                pieces_req = getattr(p, "pieces_required", -1)
+                if p.pieces_earned == 0 or pieces_req is None:
+                    zero_piece.append(p)
+                else:
+                    non_zero.append(p)
+```
+
+- Sort key is `pieces_earned` ascending with Python's stable sort, so equal keys preserve repository order (verified by `test_equal_pieces_earned_preserves_repo_order`):
+
+```605:607:src/services/reward_service.py
+            non_zero.sort(key=lambda rp: rp.pieces_earned)
+
+            return zero_piece + non_zero
+```
+
+- One-time `CLAIMED` is excluded, recurring `CLAIMED` is bucketed as fresh cycle (zero-piece).
+- Synthetic rows for active rewards without a `RewardProgress` entry are appended to `zero_piece` (matches the plan).
+- `src/web/views/rewards.py` and `frontend/src/pages/Rewards.vue` are unchanged and do not resort client-side — claimed rewards still render below active ones in the collapsible section.
+- Docstring updated to describe the new behavior.
+- Tests in `tests/test_reward_filtering.py` are updated, and the new `test_synthetic_active_reward_appears_in_zero_piece_group` regression test was added as the plan called for.
+- `TODO.md` entry added describing the change.
+
+---
+
+## 2. Bugs / correctness
+
+No correctness bugs found. A few subtle points worth documenting:
+
+### 2.1 `getattr(p, "pieces_required", -1)` sentinel is effectively dead
+
+The `-1` default is never actually hit because `RewardProgressModel.pieces_required` is declared as `int | None`, so the attribute always exists. The later check is only `pieces_req is None`, so `-1` would be bucketed as `non_zero`. This was true before this change as well (pre-existing defensive pattern), so it's not a regression — but if the intent is "unknown required → zero_piece", a plain attribute access (`p.pieces_required`) would be clearer:
+
+```python
+pieces_req = p.pieces_required
+if p.pieces_earned == 0 or pieces_req is None:
+    zero_piece.append(p)
+```
+
+Low priority — cosmetic cleanup, not a real bug.
+
+### 2.2 Edge case: `ACHIEVED` + `pieces_earned == 0`
+
+Under the old code an `ACHIEVED` entry always went to the `achieved` bucket. Under the new code, an `ACHIEVED` entry with `pieces_earned == 0` (only possible when `pieces_required == 0`, an invalid/nonsensical config) would be placed in `zero_piece`. This isn't a real-world concern — `pieces_required == 0` shouldn't exist — but it's worth noting that the new code no longer treats `ACHIEVED` as its own bucket.
+
+### 2.3 Ordering of synthetic zero-piece entries
+
+Synthetic active-reward entries are appended to `zero_piece` *after* the main loop, so they always appear at the end of the zero-piece block regardless of the natural repo order. That's acceptable, but if product intent is "zero-piece sorted by reward creation order" you'd want to merge-sort them. Probably fine as-is — just undocumented.
+
+---
+
+## 3. Data alignment
+
+No issues. Server still emits `piecesEarned` / `piecesRequired` (camelCase) in `src/web/views/rewards.py`, and the Vue page consumes those keys unchanged. Claimed list props (`claimedRewards`, `claimedAt`, `timesClaimed`) are likewise untouched.
+
+---
+
+## 4. Scope / unexpected side effects
+
+### 4.1 Bot behavior also changes (not explicitly mentioned in the plan)
+
+`get_user_reward_progress()` is also used by the Telegram bot:
+
+- `src/bot/handlers/reward_handlers.py` lines 191 and 486 (the `/progress` screen and the claim-success summary).
+- Output is rendered in order by `format_claim_success_with_progress` in `src/bot/formatters.py`.
+
+The plan scope is "web app Rewards page", but this change silently updates the bot's progress listing order too (zero-piece first, then ascending by pieces_earned, instead of percentage-descending). That's arguably consistent UX across clients, but it's a user-visible behavior change the plan didn't call out. Options:
+
+1. Keep it (unify ordering across web + bot) and update the bot's user docs / screenshots if any.
+2. Introduce a separate sort-order parameter and let the bot keep its old ordering.
+
+If the intent is #1, everything is already done — just acknowledge the cross-client impact.
+
+### 4.2 Unrelated TODO flips
+
+The diff flips two Analytics TODO items from `[ ]` to `[x]`:
+
+```diff
+-- [ ] **User Analytics Dashboard**
++- [x] **User Analytics Dashboard**
+...
+-- [ ] **Habit Performance Metrics**
++- [x] **Habit Performance Metrics**
+```
+
+These are unrelated to feature 0043 and look like they were landed together by accident. If they were completed by a separate change they should be in a separate commit; otherwise revert.
+
+---
+
+## 5. Over-engineering / refactor concerns
+
+None. The function is slightly shorter than before (dropped the 3-bucket partition and the unreachable `else` log). Readability is marginally better.
+
+---
+
+## 6. Style / consistency
+
+- Docstring clearly describes the new semantics and is accurate.
+- The file is large (700+ lines) but that predates this change; no action needed here.
+- Trailing `else: logger.warning("Unexpected reward status …")` branch was removed. It was unreachable given the three-valued `RewardStatus` enum, so removal is correct and reduces noise.
+
+---
+
+## 7. Test coverage
+
+Good. Coverage of the ordering contract:
+
+- `test_non_zero_sorted_by_pieces_earned_ascending`
+- `test_achieved_and_pending_share_non_zero_bucket`
+- `test_zero_piece_rewards_appear_first`
+- `test_mixed_ordering_all_groups`
+- `test_one_piece_away_is_ordered_by_pieces_earned`
+- `test_equal_pieces_earned_preserves_repo_order`
+- `test_pieces_required_none_goes_to_zero_piece_group`
+- `test_synthetic_active_reward_appears_in_zero_piece_group` (new)
+- `test_claimed_recurring_reward_visible_as_never_won`
+- `test_active_reward_without_progress_visible`
+
+Filter coverage (claimed hidden, recurring visible, etc.) is unchanged. All 17 tests pass locally.
+
+Nice-to-have tests not strictly required:
+
+- A test that asserts one-time `CLAIMED` entries with `pieces_earned > 0` aren't leaked into `zero_piece` (current logic `continue`s, so it's safe, but explicit coverage would help).
+- A test mixing a synthetic active reward *and* a progress-row zero-piece reward to pin down their relative order.
+
+---
+
+## 8. Recommendation
+
+Approve with two small follow-ups:
+
+1. **Split the TODO.md Analytics flips into their own commit** (scope hygiene).
+2. **Decide/document whether the bot listing also adopts the new order intentionally** — if yes, a one-line note in the PR description is enough; if no, scope the ordering change to the web view (e.g. sort in `rewards_page()` rather than in the service).
+
+Everything else is ready to merge.

--- a/src/services/reward_service.py
+++ b/src/services/reward_service.py
@@ -549,53 +549,42 @@ class RewardService:
         """Get all reward progress for a user.
 
         Returns all active rewards sorted by:
-        1. Pending rewards (pieces > 0) sorted by fill percentage descending
-        2. Achieved rewards (ready to claim)
-        3. Never-won rewards (0 pieces earned)
+        1. Zero-piece rewards first — ``pieces_earned == 0`` or
+           ``pieces_required`` unknown (includes synthetic entries for active
+           rewards without a progress row, and recurring CLAIMED rewards which
+           are treated as a fresh cycle).
+        2. Non-zero rewards sorted by ``pieces_earned`` ascending. Both
+           PENDING and ACHIEVED rewards share this bucket.
 
-        Active rewards without a RewardProgress entry are included as never-won.
-        Recurring rewards with CLAIMED status are shown as never-won (fresh cycle).
+        One-time CLAIMED rewards are excluded; they surface via
+        ``get_claimed_rewards`` and are rendered separately in the web UI.
         """
 
         async def _impl() -> list[RewardProgress]:
             results = await maybe_await(self.progress_repo.get_all_by_user(user_id))
             coerced = [self._coerce_progress(r) for r in results]
 
-            # Track which rewards already have progress entries
             progress_reward_ids = set()
 
-            # Split into 3 groups (single pass).
-            pending = []
-            achieved = []
-            never_won = []
+            zero_piece: list[RewardProgress] = []
+            non_zero: list[RewardProgress] = []
             for p in coerced:
                 progress_reward_ids.add(
                     int(p.reward_id) if isinstance(p.reward_id, str) else p.reward_id
                 )
                 status = p.get_status()
                 if status == RewardStatus.CLAIMED:
-                    # Recurring rewards: treat as never-won (fresh cycle)
                     reward_obj = getattr(p, "reward", None)
                     if reward_obj and getattr(reward_obj, "is_recurring", False):
-                        never_won.append(p)
-                    # One-time claimed rewards: skip (they'll be auto-deactivated)
+                        zero_piece.append(p)
                     continue
-                elif status == RewardStatus.ACHIEVED:
-                    achieved.append(p)
-                elif status == RewardStatus.PENDING:
-                    # Never-won: no progress, or pieces_required unknown.
-                    pieces_req = getattr(p, "pieces_required", -1)
-                    if p.pieces_earned == 0 or pieces_req is None:
-                        never_won.append(p)
-                    else:
-                        pending.append(p)
-                else:
-                    logger.warning(
-                        "Unexpected reward status %s for progress %s — skipping",
-                        status, getattr(p, "id", "?"),
-                    )
 
-            # Include active rewards that have no progress entry at all
+                pieces_req = getattr(p, "pieces_required", -1)
+                if p.pieces_earned == 0 or pieces_req is None:
+                    zero_piece.append(p)
+                else:
+                    non_zero.append(p)
+
             active_rewards = await maybe_await(
                 self.reward_repo.get_all_active(user_id)
             )
@@ -611,15 +600,11 @@ class RewardService:
                         times_claimed=0,
                         reward=reward,
                     )
-                    never_won.append(synthetic)
+                    zero_piece.append(synthetic)
 
-            # Sort pending by fill percentage descending.
-            pending.sort(
-                key=lambda rp: rp.pieces_earned / rp.get_pieces_required(),
-                reverse=True,
-            )
+            non_zero.sort(key=lambda rp: rp.pieces_earned)
 
-            return pending + achieved + never_won
+            return zero_piece + non_zero
 
         return run_sync_or_async(_impl())
 

--- a/tests/test_reward_filtering.py
+++ b/tests/test_reward_filtering.py
@@ -107,8 +107,8 @@ class TestGetUserRewardProgress:
         result = await service.get_user_reward_progress("1")
 
         assert len(result) == 2
-        # Pending (40%) first, then never-won (0/5) last
-        assert [r.reward_id for r in result] == [2, 1]
+        # Zero-piece (0/5) first, then non-zero (4/10)
+        assert [r.reward_id for r in result] == [1, 2]
 
     @pytest.mark.asyncio
     async def test_claimed_recurring_reward_visible_as_never_won(self, service):
@@ -131,8 +131,8 @@ class TestGetUserRewardProgress:
         result = await service.get_user_reward_progress("1")
 
         assert len(result) == 2
-        # Pending (30%) first, then recurring claimed as never-won last
-        assert [r.reward_id for r in result] == [2, 1]
+        # Recurring claimed treated as zero-piece (fresh cycle) → first
+        assert [r.reward_id for r in result] == [1, 2]
 
     @pytest.mark.asyncio
     async def test_active_reward_without_progress_visible(self, service):
@@ -152,11 +152,11 @@ class TestGetUserRewardProgress:
         result = await service.get_user_reward_progress("1")
 
         assert len(result) == 2
-        # Pending (50%) first, then never-won (no progress) last
-        assert result[0].reward_id == 1
-        assert result[1].reward_id == 99
-        assert result[1].pieces_earned == 0
-        assert result[1].pieces_required == 3
+        # Synthetic zero-piece reward (no progress row) first, then non-zero (5/10)
+        assert result[0].reward_id == 99
+        assert result[0].pieces_earned == 0
+        assert result[0].pieces_required == 3
+        assert result[1].reward_id == 1
 
     @pytest.mark.asyncio
     async def test_repo_filters_inactive_rewards_at_db_level(self):
@@ -213,21 +213,21 @@ class TestGetUserRewardProgress:
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_sort_by_percentage_descending(self, service):
-        """Pending rewards sorted by fill percentage high → low."""
+    async def test_non_zero_sorted_by_pieces_earned_ascending(self, service):
+        """Non-zero rewards sorted by pieces_earned ascending (1, 3, 7)."""
         service.progress_repo.get_all_by_user.return_value = [
-            _make_progress(pieces_earned=3, pieces_required=10, reward_id=1),   # 30%
-            _make_progress(pieces_earned=7, pieces_required=10, reward_id=2),   # 70%
-            _make_progress(pieces_earned=1, pieces_required=2, reward_id=3),    # 50%
+            _make_progress(pieces_earned=7, pieces_required=10, reward_id=1),
+            _make_progress(pieces_earned=3, pieces_required=10, reward_id=2),
+            _make_progress(pieces_earned=1, pieces_required=10, reward_id=3),
         ]
 
         result = await service.get_user_reward_progress("1")
 
-        assert [r.reward_id for r in result] == [2, 3, 1]
+        assert [r.reward_id for r in result] == [3, 2, 1]
 
     @pytest.mark.asyncio
-    async def test_achieved_after_pending(self, service):
-        """Achieved rewards come after all pending rewards."""
+    async def test_achieved_and_pending_share_non_zero_bucket(self, service):
+        """Achieved and pending both belong to the non-zero bucket, sorted by pieces_earned."""
         service.progress_repo.get_all_by_user.return_value = [
             _make_progress(pieces_earned=10, pieces_required=10, reward_id=1),  # achieved
             _make_progress(pieces_earned=5, pieces_required=10, reward_id=2),   # pending
@@ -235,84 +235,104 @@ class TestGetUserRewardProgress:
 
         result = await service.get_user_reward_progress("1")
 
-        assert result[0].reward_id == 2   # pending first
-        assert result[1].reward_id == 1   # achieved second
+        # pending (5) before achieved (10) because 5 < 10
+        assert [r.reward_id for r in result] == [2, 1]
 
     @pytest.mark.asyncio
-    async def test_never_won_at_bottom(self, service):
-        """Rewards with 0 pieces earned appear last."""
+    async def test_zero_piece_rewards_appear_first(self, service):
+        """Rewards with 0 pieces earned appear first in the list."""
         service.progress_repo.get_all_by_user.return_value = [
-            _make_progress(pieces_earned=0, pieces_required=10, reward_id=1),   # never won
-            _make_progress(pieces_earned=5, pieces_required=10, reward_id=2),   # pending
+            _make_progress(pieces_earned=5, pieces_required=10, reward_id=1),   # non-zero
+            _make_progress(pieces_earned=0, pieces_required=10, reward_id=2),   # zero-piece
         ]
 
         result = await service.get_user_reward_progress("1")
 
-        assert result[0].reward_id == 2   # pending first
-        assert result[1].reward_id == 1   # never-won last
+        assert result[0].reward_id == 2   # zero-piece first
+        assert result[1].reward_id == 1   # non-zero last
 
     @pytest.mark.asyncio
     async def test_mixed_ordering_all_groups(self, service):
-        """Full ordering: pending (by %) → achieved → never-won."""
+        """Full ordering: zero-piece first → non-zero ascending by pieces_earned; claimed excluded."""
         service.progress_repo.get_all_by_user.return_value = [
-            _make_progress(pieces_earned=0, pieces_required=5, reward_id=1),    # never won
-            _make_progress(pieces_earned=10, pieces_required=10, reward_id=2),  # achieved
-            _make_progress(pieces_earned=3, pieces_required=10, reward_id=3),   # 30%
-            _make_progress(pieces_earned=7, pieces_required=10, reward_id=4),   # 70%
+            _make_progress(pieces_earned=7, pieces_required=10, reward_id=1),   # non-zero
+            _make_progress(pieces_earned=0, pieces_required=5, reward_id=2),    # zero-piece
+            _make_progress(pieces_earned=10, pieces_required=10, reward_id=3),  # achieved (non-zero)
+            _make_progress(pieces_earned=3, pieces_required=10, reward_id=4),   # non-zero
             _make_progress(pieces_earned=5, pieces_required=5, claimed=True, reward_id=5),  # claimed
         ]
 
         result = await service.get_user_reward_progress("1")
 
         ids = [r.reward_id for r in result]
-        # claimed (id=5) excluded; order: 70% → 30% → achieved → never-won
-        assert ids == [4, 3, 2, 1]
+        # claimed (id=5) excluded; zero-piece (id=2) first;
+        # non-zero ascending by pieces_earned: 3 → 7 → 10
+        assert ids == [2, 4, 1, 3]
 
     # ------------------------------------------------------------------
     # Edge cases
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_one_piece_away_is_pending_not_achieved(self, service):
-        """Reward at pieces_required-1 stays in pending group, not achieved."""
+    async def test_one_piece_away_is_ordered_by_pieces_earned(self, service):
+        """Achieved and nearly-achieved entries order by pieces_earned alongside zero-piece first."""
         service.progress_repo.get_all_by_user.return_value = [
-            _make_progress(pieces_earned=9, pieces_required=10, reward_id=1),  # 90% pending
+            _make_progress(pieces_earned=9, pieces_required=10, reward_id=1),   # non-zero
             _make_progress(pieces_earned=10, pieces_required=10, reward_id=2),  # achieved
-            _make_progress(pieces_earned=0, pieces_required=1, reward_id=3),    # never-won (0/1)
+            _make_progress(pieces_earned=0, pieces_required=1, reward_id=3),    # zero-piece
         ]
 
         result = await service.get_user_reward_progress("1")
 
         ids = [r.reward_id for r in result]
-        # 90% pending first, then achieved, then never-won
-        assert ids == [1, 2, 3]
+        # zero-piece (id=3) first; then non-zero ascending: 9 → 10
+        assert ids == [3, 1, 2]
 
     @pytest.mark.asyncio
-    async def test_equal_percentage_preserves_repo_order(self, service):
-        """Rewards with the same fill % keep their repository order (stable sort)."""
+    async def test_equal_pieces_earned_preserves_repo_order(self, service):
+        """Rewards with the same pieces_earned keep their repository order (stable sort)."""
         service.progress_repo.get_all_by_user.return_value = [
-            _make_progress(pieces_earned=5, pieces_required=10, reward_id=1),   # 50%
-            _make_progress(pieces_earned=1, pieces_required=2, reward_id=2),    # 50%
-            _make_progress(pieces_earned=3, pieces_required=6, reward_id=3),    # 50%
+            _make_progress(pieces_earned=5, pieces_required=10, reward_id=1),
+            _make_progress(pieces_earned=5, pieces_required=20, reward_id=2),
+            _make_progress(pieces_earned=5, pieces_required=7, reward_id=3),
         ]
 
         result = await service.get_user_reward_progress("1")
 
-        # Python's stable sort preserves insertion order for equal keys
         assert [r.reward_id for r in result] == [1, 2, 3]
 
     @pytest.mark.asyncio
-    async def test_pieces_required_none_goes_to_never_won(self, service):
-        """Reward with pieces_required=None is bucketed into never-won, not pending."""
+    async def test_pieces_required_none_goes_to_zero_piece_group(self, service):
+        """Reward with pieces_required=None is bucketed into zero-piece (first)."""
         service.progress_repo.get_all_by_user.return_value = [
-            _make_progress(pieces_earned=5, pieces_required=10, reward_id=1),     # pending 50%
-            _make_progress(pieces_earned=3, pieces_required=None, reward_id=2),   # never-won
+            _make_progress(pieces_earned=5, pieces_required=10, reward_id=1),     # non-zero
+            _make_progress(pieces_earned=3, pieces_required=None, reward_id=2),   # zero-piece (no required)
         ]
 
         result = await service.get_user_reward_progress("1")
 
-        # pending first, then never-won (pieces_required=None)
-        assert [r.reward_id for r in result] == [1, 2]
+        # zero-piece (pieces_required=None) first, then non-zero
+        assert [r.reward_id for r in result] == [2, 1]
+
+    @pytest.mark.asyncio
+    async def test_synthetic_active_reward_appears_in_zero_piece_group(self, service):
+        """An active reward without a progress row is synthesized as zero-piece and appears first."""
+        from unittest.mock import Mock
+
+        reward_no_progress = Mock()
+        reward_no_progress.id = 42
+        reward_no_progress.pieces_required = 4
+        reward_no_progress.is_recurring = False
+
+        service.progress_repo.get_all_by_user.return_value = [
+            _make_progress(pieces_earned=2, pieces_required=10, reward_id=1),  # non-zero
+        ]
+        service.reward_repo.get_all_active.return_value = [reward_no_progress]
+
+        result = await service.get_user_reward_progress("1")
+
+        assert [r.reward_id for r in result] == [42, 1]
+        assert result[0].pieces_earned == 0
 
     @pytest.mark.asyncio
     async def test_empty_list_returns_empty(self, service):


### PR DESCRIPTION
## Summary
- Reorder active rewards: zero-piece first (incl. synthetic entries + recurring CLAIMED treated as fresh cycle), then non-zero ascending by `pieces_earned`
- One-time CLAIMED rewards still excluded from the active list — they surface via `get_claimed_rewards` / the existing claimed section in `frontend/src/pages/Rewards.vue`
- Mark completed TODO entries as done (this feature + Analytics items from merged PRs #42 / #43)
- Include `docs/features/0043_PLAN.md` and `docs/features/0043_REVIEW.md` for traceability

## Notes
- `get_user_reward_progress()` is also used by the Telegram bot (`src/bot/handlers/reward_handlers.py:191` and `:486`), so the bot's `/progress` ordering changes too. This is intentional — unified UX across web and bot.
- See `docs/features/0043_REVIEW.md` for the full review; all items accepted as-is.

## Test plan
- [ ] `uv run pytest tests/test_reward_filtering.py -v` — all 17 tests pass
- [ ] Load the web Rewards page and verify zero-piece rewards appear before non-zero, and non-zero are sorted ascending by `pieces_earned`
- [ ] Verify claimed one-time rewards still render only in the collapsible claimed section
- [ ] In the Telegram bot, run `/progress` and confirm the new ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)