### PR TITLE
fix: deploy-caddy fails loudly on transient errors

### DIFF
--- a/.github/workflows/deploy-caddy.yml
+++ b/.github/workflows/deploy-caddy.yml
@@ -195,12 +195,22 @@ jobs:
       - name: Deploy containers with Caddy
         run: |
           ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=10 ${{ secrets.SSH_USER }}@${{ secrets.SERVER_HOST }} << 'DEPLOY'
+            set -euo pipefail
             cd ${{ secrets.DEPLOY_PATH }}
 
-            # Login to GitHub Container Registry
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            # Login to GitHub Container Registry — retry on transient network failures
+            login_attempts=0
+            until echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin; do
+              login_attempts=$((login_attempts + 1))
+              if [ "$login_attempts" -ge 3 ]; then
+                echo "ERROR: docker login ghcr.io failed 3 times"; exit 1
+              fi
+              echo "docker login attempt $login_attempts failed; retrying in 5s..."
+              sleep 5
+            done
 
-            # Pull latest application image
+            # Pull FIRST — only tear down running containers if the new image is in hand.
+            # Avoids tearing down prod when ghcr.io is unreachable.
             docker-compose --env-file .env -f docker/docker-compose.yml pull web
 
             # Stop existing containers gracefully
@@ -216,11 +226,20 @@ jobs:
             # Show container status
             echo "Container Status:"
             docker-compose --env-file .env -f docker/docker-compose.yml ps
+
+            # Fail loudly if the web container isn't actually running
+            web_state=$(docker inspect habit_reward_web --format='{{.State.Status}}' 2>/dev/null || echo "missing")
+            if [ "$web_state" != "running" ]; then
+              echo "ERROR: habit_reward_web is not running (state=$web_state)"
+              docker-compose --env-file .env -f docker/docker-compose.yml logs --tail=50 web || true
+              exit 1
+            fi
           DEPLOY
 
       - name: Verify deployment health
         run: |
           ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=10 ${{ secrets.SSH_USER }}@${{ secrets.SERVER_HOST }} << 'VERIFY'
+            set -uo pipefail
             cd ${{ secrets.DEPLOY_PATH }}
 
             echo "Checking container logs:"
@@ -243,16 +262,20 @@ jobs:
 
       - name: Check HTTPS endpoint
         run: |
+          set -euo pipefail
           echo "Testing HTTPS endpoint..."
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://habitreward.org/admin/login/ || echo "000")
-
-          if [ "$STATUS" == "200" ] || [ "$STATUS" == "302" ]; then
-            echo "✅ HTTPS is working! (HTTP $STATUS)"
-          else
-            echo "⚠️ Warning: Unexpected HTTP status: $STATUS"
-            echo "This might be normal on first deployment (SSL cert provisioning)"
-            # Don't fail the workflow - Caddy might still be provisioning cert
-          fi
+          STATUS=""
+          for attempt in 1 2 3 4 5; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://habitreward.org/admin/login/ || echo "000")
+            if [ "$STATUS" = "200" ] || [ "$STATUS" = "302" ]; then
+              echo "✅ HTTPS is working! (HTTP $STATUS, attempt $attempt)"
+              exit 0
+            fi
+            echo "Attempt $attempt: HTTP $STATUS — retrying in 10s..."
+            sleep 10
+          done
+          echo "❌ HTTPS health check failed after 5 attempts (last status: $STATUS)"
+          exit 1
 
       - name: Check SSL certificate
         run: |

--- a/.github/workflows/deploy-caddy.yml
+++ b/.github/workflows/deploy-caddy.yml
@@ -210,8 +210,18 @@ jobs:
             done
 
             # Pull FIRST — only tear down running containers if the new image is in hand.
-            # Avoids tearing down prod when ghcr.io is unreachable.
-            docker-compose --env-file .env -f docker/docker-compose.yml pull web
+            # Avoids tearing down prod when ghcr.io is unreachable. Retry on
+            # transient network failures (defense-in-depth above docker's
+            # internal layer retries).
+            pull_attempts=0
+            until docker-compose --env-file .env -f docker/docker-compose.yml pull web; do
+              pull_attempts=$((pull_attempts + 1))
+              if [ "$pull_attempts" -ge 3 ]; then
+                echo "ERROR: docker-compose pull web failed 3 times"; exit 1
+              fi
+              echo "pull attempt $pull_attempts failed; retrying in 5s..."
+              sleep 5
+            done
 
             # Stop existing containers gracefully
             docker-compose --env-file .env -f docker/docker-compose.yml down --timeout 30
@@ -227,11 +237,19 @@ jobs:
             echo "Container Status:"
             docker-compose --env-file .env -f docker/docker-compose.yml ps
 
-            # Fail loudly if the web container isn't actually running
+            # Fail loudly if either container isn't actually running. The HTTPS
+            # health check would catch this in ~50s, but checking here makes the
+            # failure faster and easier to diagnose.
             web_state=$(docker inspect habit_reward_web --format='{{.State.Status}}' 2>/dev/null || echo "missing")
             if [ "$web_state" != "running" ]; then
               echo "ERROR: habit_reward_web is not running (state=$web_state)"
               docker-compose --env-file .env -f docker/docker-compose.yml logs --tail=50 web || true
+              exit 1
+            fi
+            caddy_state=$(docker inspect habit_reward_caddy --format='{{.State.Status}}' 2>/dev/null || echo "missing")
+            if [ "$caddy_state" != "running" ]; then
+              echo "ERROR: habit_reward_caddy is not running (state=$caddy_state)"
+              docker-compose --env-file .env -f docker/docker-compose.yml logs --tail=50 caddy || true
               exit 1
             fi
           DEPLOY
@@ -260,6 +278,9 @@ jobs:
       - name: Wait for services to stabilize
         run: sleep 30
 
+      # Note: this strict check will fail on first deployment if SSL cert
+      # provisioning takes longer than ~80s (30s stabilization + 5×10s retries).
+      # That is intentional — prefer failing loudly over silent success.
       - name: Check HTTPS endpoint
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Context — today's outage

The PR #45 merge at 10:35 UTC triggered a deploy that *silently failed* and took the site down for ~16 minutes. Browser symptom: `ERR_QUIC_PROTOCOL_ERROR` (Caddy + web container both gone).

What actually happened on the server during run [25793743540](https://github.com/erzhan12/habit-reward/actions/runs/25793743540):

```
10:41:45  docker login ghcr.io → TIMEOUT (transient ghcr.io network blip)
10:41:46  docker-compose pull web → "denied" (login state empty)
10:41:47  docker-compose down --timeout 30 → caddy + web both stopped+removed
10:41:49  docker-compose up -d → "denied" again
10:42:05  Container Status: (empty)
10:42:08  docker inspect habit_reward_web → "no such object"
```

The workflow still reported `success` because three layers were lying:

1. The SSH heredoc's exit code reflected only the last command (`docker-compose ps`, returns 0 even with no containers).
2. The verify-health step used `|| echo "Health check not available yet"`, swallowing the missing-container error.
3. The HTTPS check used `|| echo "000"` and only emitted a warning on non-200/302 — never `exit 1`.

Manual re-run of the workflow restored the site (run [25794811244](https://github.com/erzhan12/habit-reward/actions/runs/25794811244)).

## Summary
- **Pull-then-down ordering** plus a 3-attempt retry on `docker login ghcr.io`. If the registry is unreachable, we abort before tearing down the running containers. The invariant "uptime cannot be lost without first having a new image in hand" is restored.
- `set -euo pipefail` on the deploy SSH heredoc, plus an explicit `docker inspect ... State.Status=running` check at the end. Either makes the SSH command exit non-zero on real failure.
- The HTTPS health check now retries 5× with 10s sleep and `exit 1` on persistent failure. A fully-down site can no longer report success.
- The verify-health step keeps its informational role (logs dump) but gets `set -uo pipefail` for safety.

## Test plan
- [x] Site is up (verified `curl https://habitreward.org/admin/login/` → HTTP 200)
- [ ] Merge this PR → the deploy it triggers will exercise the new code path
- [ ] Confirm the workflow still reports success when ghcr.io is healthy (this PR shouldn't change happy-path behavior)
- [ ] Manual gauntlet (do NOT run in prod): chaos-test by temporarily breaking `secrets.GITHUB_TOKEN` and confirming the next deploy fails *before* `docker-compose down` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)