### PR TITLE
feat: desaturate fire emoji on completed streak indicator

### DIFF
--- a/frontend/src/components/HabitCardContent.vue
+++ b/frontend/src/components/HabitCardContent.vue
@@ -15,7 +15,7 @@
       <span
         class="text-sm"
         :class="streakColorClasses"
-        :style="habit.completedToday ? 'filter: grayscale(1) opacity(0.5)' : null"
+        :style="emojiFilterStyle"
       >
         🔥
       </span>
@@ -39,4 +39,8 @@ const streakColorClasses = computed(() => [
   props.habit.completedToday ? "text-text-muted" : "text-streak-fire",
   props.streakClass,
 ]);
+
+const emojiFilterStyle = computed(() =>
+  props.habit.completedToday ? { filter: "grayscale(1) opacity(0.5)" } : null,
+);
 </script>

--- a/frontend/src/components/HabitCardContent.vue
+++ b/frontend/src/components/HabitCardContent.vue
@@ -12,7 +12,11 @@
       </span>
     </div>
     <div v-if="habit.streak > 0" class="flex items-center gap-1 mt-1">
-      <span class="text-sm" :class="streakColorClasses">
+      <span
+        class="text-sm"
+        :class="streakColorClasses"
+        :style="habit.completedToday ? 'filter: grayscale(1) opacity(0.5)' : null"
+      >
         🔥
       </span>
       <span class="text-xs font-medium" :class="streakColorClasses">

--- a/frontend/tests/HabitCardContent.spec.js
+++ b/frontend/tests/HabitCardContent.spec.js
@@ -43,6 +43,7 @@ describe("HabitCardContent", () => {
     expect(text.classes()).toContain("streak-fire-bounce");
     expect(emoji.classes()).not.toContain("text-text-muted");
     expect(text.classes()).not.toContain("text-text-muted");
+    expect(emoji.attributes("style")).toBeFalsy();
   });
 
   it("uses muted streak styling for completed habits", () => {
@@ -58,6 +59,7 @@ describe("HabitCardContent", () => {
     expect(text.classes()).toContain("text-text-muted");
     expect(emoji.classes()).toContain("streak-fire-bounce");
     expect(text.classes()).toContain("streak-fire-bounce");
+    expect(emoji.attributes("style")).toContain("filter: grayscale(1) opacity(0.5)");
   });
 
   it("does not render the streak block when there is no streak", () => {


### PR DESCRIPTION
## Summary
- Follow-up to #46: the streak text was dimmed to gray on completed habits, but the 🔥 emoji glyph stayed full color because CSS `color` does not affect color-emoji rendering on most platforms.
- Adds `filter: grayscale(1) opacity(0.5)` inline on the emoji span when `habit.completedToday` is true, so the emoji visually matches the muted text.
- Non-completed habits unchanged (full color emoji + orange `text-streak-fire` text).

## Test plan
- [x] `npx vitest run HabitCardContent` passes (4/4)
- [ ] Visual check on Today page: completed card → emoji desaturated; incomplete card with streak → emoji vivid

🤖 Generated with [Claude Code](https://claude.com/claude-code)