### PR TITLE
fix: gray emoji filter blocked by CSP — move to CSS class

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -502,6 +502,8 @@ Standardized: `{"error": {"code": "ERROR_CODE", "message": "...", "details": {}}
 
 `ContentSecurityPolicyMiddleware` (`src/web/middleware.py`) sets CSP, X-Content-Type-Options, X-Frame-Options, Referrer-Policy in production (`DEBUG=False`). CSP nonce via `request.csp_nonce` → `csp_nonce` context processor → `<meta name="csp-nonce">`.
 
+**Vue inline `:style` is blocked in production**: `style-src` includes both `nonce-...` and `'unsafe-inline'`. Per CSP Level 3, when a nonce is present, `'unsafe-inline'` is IGNORED, so any `style=""` attribute without the nonce is dropped. Vue's `:style` binding emits nonce-less inline styles → no visual effect in prod (but works in dev/Vitest). Put the rule in a CSS class (`frontend/src/animations.css` or a `<style>` block) and toggle with `:class` instead.
+
 ### Authentication Endpoint Hardening
 
 **Rate limiting**: All auth endpoints use `django-ratelimit`. Rate configurable via `settings.AUTH_RATE_LIMIT` (default `'10/m'`). Always pair `method=` with `@require_POST`/`@require_GET`. Dashboard actions: `settings.DASHBOARD_ACTION_RATE_LIMIT` (default `'60/m'`), shared `group="dashboard_action"`.

--- a/frontend/src/animations.css
+++ b/frontend/src/animations.css
@@ -73,6 +73,10 @@
   display: inline-block;
 }
 
+.streak-emoji-muted {
+  filter: grayscale(1) opacity(0.5);
+}
+
 /* ── Hover micro-interactions ──────────────────────────── */
 
 .hover-micro-scale {

--- a/frontend/src/components/HabitCardContent.vue
+++ b/frontend/src/components/HabitCardContent.vue
@@ -14,8 +14,7 @@
     <div v-if="habit.streak > 0" class="flex items-center gap-1 mt-1">
       <span
         class="text-sm"
-        :class="streakColorClasses"
-        :style="emojiFilterStyle"
+        :class="[streakColorClasses, { 'streak-emoji-muted': habit.completedToday }]"
       >
         🔥
       </span>
@@ -39,8 +38,4 @@ const streakColorClasses = computed(() => [
   props.habit.completedToday ? "text-text-muted" : "text-streak-fire",
   props.streakClass,
 ]);
-
-const emojiFilterStyle = computed(() =>
-  props.habit.completedToday ? { filter: "grayscale(1) opacity(0.5)" } : null,
-);
 </script>

--- a/frontend/tests/HabitCardContent.spec.js
+++ b/frontend/tests/HabitCardContent.spec.js
@@ -43,7 +43,7 @@ describe("HabitCardContent", () => {
     expect(text.classes()).toContain("streak-fire-bounce");
     expect(emoji.classes()).not.toContain("text-text-muted");
     expect(text.classes()).not.toContain("text-text-muted");
-    expect(emoji.attributes("style")).toBeFalsy();
+    expect(emoji.classes()).not.toContain("streak-emoji-muted");
   });
 
   it("uses muted streak styling for completed habits", () => {
@@ -59,7 +59,7 @@ describe("HabitCardContent", () => {
     expect(text.classes()).toContain("text-text-muted");
     expect(emoji.classes()).toContain("streak-fire-bounce");
     expect(text.classes()).toContain("streak-fire-bounce");
-    expect(emoji.attributes("style")).toContain("filter: grayscale(1) opacity(0.5)");
+    expect(emoji.classes()).toContain("streak-emoji-muted");
   });
 
   it("does not render the streak block when there is no streak", () => {


### PR DESCRIPTION
## Summary
- Follow-up to #49. The grayscale filter on the completed-habit streak emoji had no visual effect in production: the emoji stayed orange.
- **Root cause**: production CSP sets `style-src 'self' 'nonce-...' 'unsafe-inline'`. Per CSP Level 3, when a nonce is present `'unsafe-inline'` is **ignored**, so Vue's `:style` binding (which emits a nonce-less `style=""` attribute) is dropped by the browser. The behavior worked in dev/Vitest because CSP only applies in `DEBUG=False`.
- **Fix**: extract the filter into a `.streak-emoji-muted` class in `animations.css` and toggle it via `:class`. Stylesheets are served from `'self'` so no nonce is needed.
- Documented the pitfall in `RULES.md § Security Headers` so the next inline-style attempt doesn't repeat this.

## Test plan
- [x] `cd frontend && npx vitest run HabitCardContent` — 4/4 passes (asserts class presence on completed, absence on incomplete)
- [ ] Visual check on habitreward.org Today page after deploy: completed habit's 🔥 renders desaturated

🤖 Generated with [Claude Code](https://claude.com/claude-code)