### PR TITLE
fix: split filter/opacity so CSS minifier doesn't break the rule

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -506,6 +506,8 @@ Standardized: `{"error": {"code": "ERROR_CODE", "message": "...", "details": {}}
 
 `filter: grayscale(1) opacity(0.5);` in source CSS minifies to `filter:grayscale()opacity(.5)` (no space) in the built bundle, which is invalid CSS — browsers silently drop the rule. Symptom: filter has no visual effect in production but works in dev (Vite serves un-minified source). Fix: split combined filter+opacity into separate properties — `filter: grayscale(1); opacity: 0.5;`. Verified with playwright/Chromium on the built bundle. (Encountered while implementing the muted streak emoji.)
 
+Note: Vue 3's `:style` binding uses CSSOM property setting (`el.style[key] = value`), not parser-inserted `style=""` HTML attributes — so it's NOT subject to CSP `style-src-attr`. Existing `:style` bindings (progress bars, animations, transforms) work fine under our production CSP.
+
 ### Authentication Endpoint Hardening
 
 **Rate limiting**: All auth endpoints use `django-ratelimit`. Rate configurable via `settings.AUTH_RATE_LIMIT` (default `'10/m'`). Always pair `method=` with `@require_POST`/`@require_GET`. Dashboard actions: `settings.DASHBOARD_ACTION_RATE_LIMIT` (default `'60/m'`), shared `group="dashboard_action"`.

--- a/RULES.md
+++ b/RULES.md
@@ -502,7 +502,9 @@ Standardized: `{"error": {"code": "ERROR_CODE", "message": "...", "details": {}}
 
 `ContentSecurityPolicyMiddleware` (`src/web/middleware.py`) sets CSP, X-Content-Type-Options, X-Frame-Options, Referrer-Policy in production (`DEBUG=False`). CSP nonce via `request.csp_nonce` → `csp_nonce` context processor → `<meta name="csp-nonce">`.
 
-**Vue inline `:style` is blocked in production**: `style-src` includes both `nonce-...` and `'unsafe-inline'`. Per CSP Level 3, when a nonce is present, `'unsafe-inline'` is IGNORED, so any `style=""` attribute without the nonce is dropped. Vue's `:style` binding emits nonce-less inline styles → no visual effect in prod (but works in dev/Vitest). Put the rule in a CSS class (`frontend/src/animations.css` or a `<style>` block) and toggle with `:class` instead.
+### Tailwind 4 / Lightning CSS minifier strips spaces between filter functions
+
+`filter: grayscale(1) opacity(0.5);` in source CSS minifies to `filter:grayscale()opacity(.5)` (no space) in the built bundle, which is invalid CSS — browsers silently drop the rule. Symptom: filter has no visual effect in production but works in dev (Vite serves un-minified source). Fix: split combined filter+opacity into separate properties — `filter: grayscale(1); opacity: 0.5;`. Verified with playwright/Chromium on the built bundle. (Encountered while implementing the muted streak emoji.)
 
 ### Authentication Endpoint Hardening
 

--- a/frontend/src/animations.css
+++ b/frontend/src/animations.css
@@ -74,7 +74,8 @@
 }
 
 .streak-emoji-muted {
-  filter: grayscale(1) opacity(0.5);
+  filter: grayscale(1);
+  opacity: 0.5;
 }
 
 /* ── Hover micro-interactions ──────────────────────────── */

--- a/frontend/src/animations.css
+++ b/frontend/src/animations.css
@@ -73,6 +73,8 @@
   display: inline-block;
 }
 
+/* Keep filter and opacity as separate properties — combining as
+   `filter: grayscale(1) opacity(0.5)` minifies to invalid CSS. */
 .streak-emoji-muted {
   filter: grayscale(1);
   opacity: 0.5;


### PR DESCRIPTION
## Real root cause of "🔥 still orange in prod" on completed habits

PRs #49 and #50 didn't fix the bug because they targeted the wrong cause. The actual problem is in CSS minification.

**Source CSS** (`animations.css`):
\`\`\`css
.streak-emoji-muted {
  filter: grayscale(1) opacity(0.5);
}
\`\`\`

**After Tailwind 4 / Lightning CSS minifies the production bundle:**
\`\`\`css
.streak-emoji-muted{filter:grayscale()opacity(.5)
\`\`\`

The minifier stripped the space between `grayscale(1)` and `opacity(0.5)` — concatenated filter functions are invalid CSS, so the browser silently drops the rule. Works in Vite dev (un-minified source) and in Vitest (jsdom doesn't apply CSS this strictly), broken only in the built bundle. That's why every previous fix "shipped clean" but didn't visibly work.

## Fix

Split into two separate CSS properties so the minifier can't collapse them together:

\`\`\`css
.streak-emoji-muted {
  filter: grayscale(1);
  opacity: 0.5;
}
\`\`\`

## Verification

Ran the built CSS through real Chromium via Playwright on a standalone test page:

\`\`\`
{
  "bright": { "filter": "none", "opacity": "1" },
  "muted":  { "filter": "grayscale(1)", "opacity": "0.5" }
}
\`\`\`

Screenshot confirmed: completed-habit emoji renders desaturated gray, incomplete-habit emoji renders full orange.

## Self-correction on PR #50

PR #50's stated root cause (production CSP nonce blocking inline `:style`) was incorrect. Vue 3's `patchStyle` runtime uses CSSOM property setting (`el.style[key] = value`), not parser-inserted `style=""` attributes, and CSSOM mutations from already-trusted JS are not subject to `style-src-attr`. The misleading note has been replaced in RULES.md with the actual lesson (minifier + filter-function spacing).

The class-based structure from #50 is kept since it's still cleaner than inline `:style` for a static value.

## Test plan
- [x] Built bundle inspected: `filter:grayscale();opacity:.5` (valid)
- [x] Playwright/Chromium computed style: `filter: grayscale(1); opacity: 0.5` applied
- [x] Visual screenshot confirms desaturated emoji
- [ ] Post-deploy hard-refresh on habitreward.org — completed habit's 🔥 should now read gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)