### PR TITLE
fix: drop streak animation on completed habits (real cause of orange 🔥)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -508,6 +508,10 @@ Standardized: `{"error": {"code": "ERROR_CODE", "message": "...", "details": {}}
 
 Note: Vue 3's `:style` binding uses CSSOM property setting (`el.style[key] = value`), not parser-inserted `style=""` HTML attributes — so it's NOT subject to CSP `style-src-attr`. Existing `:style` bindings (progress bars, animations, transforms) work fine under our production CSP.
 
+### CSS animation keyframes outrank static class properties on the same property
+
+If a class sets `filter` / `opacity` / `transform` and another class on the same element runs an animation that also touches that property, the animation wins for as long as it's running (the user-agent treats `running animation` as a higher cascade origin). Symptom: `.foo { filter: grayscale(1) }` ignored because `.bar { animation: pulseGlow ... }` keyframes set `filter: brightness(...)`. Fix is to either drop the conflicting animation class on the same element (preferred) or design keyframes to not touch the property the static class needs. The streak-emoji muted state in `HabitCardContent.vue` drops `streakClass` when `completedToday` for exactly this reason — pulseGlow animates `filter` and `opacity`, which collides with `.streak-emoji-muted`.
+
 ### Authentication Endpoint Hardening
 
 **Rate limiting**: All auth endpoints use `django-ratelimit`. Rate configurable via `settings.AUTH_RATE_LIMIT` (default `'10/m'`). Always pair `method=` with `@require_POST`/`@require_GET`. Dashboard actions: `settings.DASHBOARD_ACTION_RATE_LIMIT` (default `'60/m'`), shared `group="dashboard_action"`.

--- a/frontend/src/components/HabitCardContent.vue
+++ b/frontend/src/components/HabitCardContent.vue
@@ -36,6 +36,6 @@ const props = defineProps({
 
 const streakColorClasses = computed(() => [
   props.habit.completedToday ? "text-text-muted" : "text-streak-fire",
-  props.streakClass,
+  props.habit.completedToday ? "" : props.streakClass,
 ]);
 </script>

--- a/frontend/tests/HabitCardContent.spec.js
+++ b/frontend/tests/HabitCardContent.spec.js
@@ -57,8 +57,8 @@ describe("HabitCardContent", () => {
     expect(text.classes()).not.toContain("text-streak-fire");
     expect(emoji.classes()).toContain("text-text-muted");
     expect(text.classes()).toContain("text-text-muted");
-    expect(emoji.classes()).toContain("streak-fire-bounce");
-    expect(text.classes()).toContain("streak-fire-bounce");
+    expect(emoji.classes()).not.toContain("streak-fire-bounce");
+    expect(text.classes()).not.toContain("streak-fire-bounce");
     expect(emoji.classes()).toContain("streak-emoji-muted");
   });
 


### PR DESCRIPTION
## Why this PR exists despite #46, #49, #50, #51

After deploying #51 (CSS minification fix), I logged into habitreward.org with Playwright and grabbed computed styles on the real Today page. The emoji on completed habits was still bright orange. The 2 `.streak-emoji-muted` elements showed:

\`\`\`
filter:  brightness(1.00038)   ← should be grayscale(1)
opacity: 0.999811              ← should be 0.5
\`\`\`

Both values were being set by the `streak-fire-pulse-glow` keyframe animation (`@keyframes pulseGlow` animates `filter: brightness()` and `opacity`). **CSS animations outrank static class properties on the same property while running** — so `.streak-emoji-muted { filter: grayscale(1); opacity: 0.5 }` was overridden every frame.

The earlier audit (memory observation 888: "Animation keyframes do not enforce fire colors; streakClass safe to apply on completed habits") only checked that animations didn't enforce **color** values. It didn't check `filter` / `opacity`, which is what we ended up depending on.

## Fix

Omit `props.streakClass` from the streak emoji + text spans when `habit.completedToday`. That removes the animation entirely on completed habits — which is also semantically right: there's no reason to pulse/bounce a de-emphasized indicator.

\`\`\`vue
const streakColorClasses = computed(() => [
  props.habit.completedToday ? "text-text-muted" : "text-streak-fire",
  props.habit.completedToday ? "" : props.streakClass,  // drop animation when completed
]);
\`\`\`

## Verification

- [x] `npx vitest run HabitCardContent` — 4/4 passes (asserts `streak-fire-bounce` NOT applied when completed)
- [x] Playwright login → Today page → inspect computed styles on `.streak-emoji-muted` (will re-run after deploy to confirm `filter: grayscale(1)` and `opacity: 0.5` are now the resolved values)
- [ ] Visual check after deploy

## Lesson for RULES.md

Added under § Security Headers (CSP/minify section is already there): "CSS animation keyframes outrank static class properties on the same property". Tied to this specific incident so the next dev doesn't fight the same fight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)