### PR TITLE
fix: reward bucket sort silently bypassed on Django objects

### DIFF
--- a/src/services/reward_service.py
+++ b/src/services/reward_service.py
@@ -585,9 +585,18 @@ class RewardService:
                         zero_piece.append(p)
                     continue
 
-                # Defensive: pieces_required may be missing on partially-
-                # constructed mocks; treat absent and None as "unknown".
-                pieces_req = getattr(p, "pieces_required", None)
+                # pieces_required lives on the linked Reward in the Django
+                # model (cached by the repository) and as a direct field on the
+                # Pydantic model used in tests. Try both before treating as
+                # unknown.
+                pieces_req = None
+                if hasattr(p, "_get_pieces_required_safe"):
+                    try:
+                        pieces_req = p._get_pieces_required_safe()
+                    except (ValueError, AttributeError):
+                        pieces_req = None
+                if pieces_req is None:
+                    pieces_req = getattr(p, "pieces_required", None)
                 if p.pieces_earned == 0 or pieces_req is None:
                     zero_piece.append(p)
                 elif status == RewardStatus.ACHIEVED:

--- a/tests/test_reward_filtering.py
+++ b/tests/test_reward_filtering.py
@@ -365,6 +365,52 @@ class TestGetUserRewardProgress:
         assert [r.reward_id for r in result] == [2, 1]
 
     @pytest.mark.asyncio
+    async def test_django_model_pieces_required_via_safe_getter(self, service):
+        """Regression: real Django RewardProgress has no `pieces_required` field
+        directly — it lives on the related Reward and is exposed via
+        `_get_pieces_required_safe()`. Service must read through that method,
+        not assume `p.pieces_required` is a direct attribute, or every reward
+        falls into the zero-piece bucket and the order collapses to the
+        repository's alphabetical sort.
+        """
+        from types import SimpleNamespace
+        from src.models.reward_progress import RewardStatus
+
+        def _django_like(*, pieces_earned, pieces_required, reward_id, claimed=False):
+            obj = SimpleNamespace(
+                user_id=42,
+                reward_id=reward_id,
+                pieces_earned=pieces_earned,
+                claimed=claimed,
+                times_claimed=0,
+                _cached_pieces_required=pieces_required,
+                reward=SimpleNamespace(id=reward_id, pieces_required=pieces_required, is_recurring=False),
+            )
+            obj._get_pieces_required_safe = lambda: obj._cached_pieces_required
+            obj.get_status = lambda: (
+                RewardStatus.CLAIMED if obj.claimed
+                else RewardStatus.ACHIEVED if obj.pieces_earned >= obj._cached_pieces_required
+                else RewardStatus.PENDING
+            )
+            return obj
+
+        service.progress_repo.get_all_by_user.return_value = [
+            _django_like(pieces_earned=10, pieces_required=10, reward_id=1),  # achieved
+            _django_like(pieces_earned=5, pieces_required=7, reward_id=2),    # pending
+            _django_like(pieces_earned=5, pieces_required=5, reward_id=3),    # achieved
+            _django_like(pieces_earned=8, pieces_required=20, reward_id=4),   # pending
+        ]
+
+        result = await service.get_user_reward_progress("1")
+        ids = [r.reward_id for r in result]
+        # pending sorted by pieces_earned ASC: id=2 (5), id=4 (8)
+        # then ready_to_claim sorted by pieces_earned ASC: id=3 (5), id=1 (10)
+        assert ids == [2, 4, 3, 1], (
+            "Service must bucket Django-style RewardProgress correctly; "
+            f"got alphabetical/insertion order {ids}"
+        )
+
+    @pytest.mark.asyncio
     async def test_synthetic_active_reward_appears_in_zero_piece_group(self, service):
         """An active reward without a progress row is synthesized as zero-piece and appears first."""
         from unittest.mock import Mock


### PR DESCRIPTION
## Bug

Rewards page renders in alphabetical order on production, not the 3-bucket order PR #45 intended.

Verified by logging into habitreward.org via Playwright and dumping the JSON props delivered by the Django view:

\`\`\`
1. Basik             | 10/10 | ACHIEVED   ← should be near the bottom
2. Coffee-machine    |  5/7  | PENDING
3. Kindle Scrible    |  5/5  | ACHIEVED
4. LV Imagination    |  8/20 | PENDING
5. Massage           |  2/3  | PENDING    ← lowest pieces_earned, should be first
6. O                 |  1/1  | ACHIEVED
... (etc, alphabetical by name)
\`\`\`

Expected (from PR #45): zero-piece → pending sorted by pieces_earned → ready_to_claim sorted by pieces_earned.

## Root cause

`get_user_reward_progress()` reads pieces_required as:

\`\`\`python
pieces_req = getattr(p, "pieces_required", None)
if p.pieces_earned == 0 or pieces_req is None:
    zero_piece.append(p)
\`\`\`

- **Pydantic `RewardProgress`** (used in unit tests): `pieces_required` is a direct field → works.
- **Django `RewardProgress`** (used in production): the value lives only on the related `Reward`, exposed via `_get_pieces_required_safe()`. `getattr(p, "pieces_required", None)` always returns `None`.

With `pieces_req` always None on prod, the OR guard matched every row, every reward went to the `zero_piece` bucket, and `zero_piece` is not re-sorted — it preserves the repo's insertion order, which is `.order_by("reward__name")`. End result: alphabetical, bucket logic silently bypassed.

This wasn't caught because every existing test used the Pydantic model with the direct field.

## Fix

Prefer `_get_pieces_required_safe()` (Django path) when available, fall back to direct field (Pydantic path):

\`\`\`python
pieces_req = None
if hasattr(p, "_get_pieces_required_safe"):
    try:
        pieces_req = p._get_pieces_required_safe()
    except (ValueError, AttributeError):
        pieces_req = None
if pieces_req is None:
    pieces_req = getattr(p, "pieces_required", None)
\`\`\`

## Regression test

Added `test_django_model_pieces_required_via_safe_getter` — mounts a `SimpleNamespace` that mirrors the Django interface (`_get_pieces_required_safe()`, no direct `pieces_required` attribute) and asserts the bucket order. Without the fix this fixture would land in `zero_piece` and the assertion `[2, 4, 3, 1] == ids` fails.

## Test plan
- [x] `uv run pytest tests/test_reward_filtering.py -v` — 21/21 pass (20 existing + 1 new)
- [ ] Playwright Rewards page check on prod after deploy: order should be pending-by-pieces-earned then ready-by-pieces-earned

🤖 Generated with [Claude Code](https://claude.com/claude-code)