### PR TITLE
feat: sort pending rewards by completion ratio (closest-to-ready first)

### DIFF
--- a/src/services/reward_service.py
+++ b/src/services/reward_service.py
@@ -553,8 +553,9 @@ class RewardService:
            ``pieces_required`` unknown (includes synthetic entries for active
            rewards without a progress row, and recurring CLAIMED rewards which
            are treated as a fresh cycle).
-        2. PENDING rewards with partial progress, sorted by ``pieces_earned``
-           ascending.
+        2. PENDING rewards with partial progress, sorted by completion ratio
+           (``pieces_earned / pieces_required``) descending — closest-to-ready
+           first, so the on-page progress bars decrease monotonically.
         3. ACHIEVED (ready-to-claim) rewards last, sorted by ``pieces_earned``
            ascending. They sit just above the separate claimed-rewards section
            rendered by the web UI. An ACHIEVED reward with ``pieces_earned == 0``
@@ -585,18 +586,7 @@ class RewardService:
                         zero_piece.append(p)
                     continue
 
-                # pieces_required lives on the linked Reward in the Django
-                # model (cached by the repository) and as a direct field on the
-                # Pydantic model used in tests. Try both before treating as
-                # unknown.
-                pieces_req = None
-                if hasattr(p, "_get_pieces_required_safe"):
-                    try:
-                        pieces_req = p._get_pieces_required_safe()
-                    except (ValueError, AttributeError):
-                        pieces_req = None
-                if pieces_req is None:
-                    pieces_req = getattr(p, "pieces_required", None)
+                pieces_req = self._resolve_pieces_required(p)
                 if p.pieces_earned == 0 or pieces_req is None:
                     zero_piece.append(p)
                 elif status == RewardStatus.ACHIEVED:
@@ -621,7 +611,12 @@ class RewardService:
                     )
                     zero_piece.append(synthetic)
 
-            pending.sort(key=lambda rp: rp.pieces_earned)
+            # Pending: closest-to-ready first (descending by completion ratio)
+            # so the visual progress bars decrease monotonically down the list.
+            def _pending_sort_key(rp):
+                req = self._resolve_pieces_required(rp)
+                return -(rp.pieces_earned / req) if req else 0.0
+            pending.sort(key=_pending_sort_key)
             ready_to_claim.sort(key=lambda rp: rp.pieces_earned)
 
             return zero_piece + pending + ready_to_claim
@@ -714,6 +709,24 @@ class RewardService:
 
         return run_sync_or_async(_impl())
 
+
+    @staticmethod
+    def _resolve_pieces_required(progress: RewardProgress) -> int | None:
+        """Resolve pieces_required across model variants.
+
+        Django RewardProgress exposes the value only via `_get_pieces_required_safe()`
+        (the field lives on the related Reward, cached by the repository).
+        Pydantic RewardProgress has it as a direct field. Returns None when
+        neither path yields a value — caller should treat as "unknown".
+        """
+        if hasattr(progress, "_get_pieces_required_safe"):
+            try:
+                value = progress._get_pieces_required_safe()
+                if value is not None:
+                    return value
+            except (ValueError, AttributeError):
+                pass
+        return getattr(progress, "pieces_required", None)
 
     @staticmethod
     def _coerce_progress(progress: RewardProgress) -> RewardProgress:

--- a/tests/test_reward_filtering.py
+++ b/tests/test_reward_filtering.py
@@ -324,8 +324,8 @@ class TestGetUserRewardProgress:
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_one_piece_away_is_ordered_by_pieces_earned(self, service):
-        """Zero-piece rewards appear first, then pending sorted by pieces_earned, then achieved rewards last."""
+    async def test_groups_bucketed_correctly_across_zero_pending_achieved(self, service):
+        """Group rank takes precedence: zero-piece first, then pending, then achieved last."""
         service.progress_repo.get_all_by_user.return_value = [
             _make_progress(pieces_earned=9, pieces_required=10, reward_id=1),   # pending
             _make_progress(pieces_earned=10, pieces_required=10, reward_id=2),  # achieved

--- a/tests/test_reward_filtering.py
+++ b/tests/test_reward_filtering.py
@@ -213,17 +213,17 @@ class TestGetUserRewardProgress:
     # ------------------------------------------------------------------
 
     @pytest.mark.asyncio
-    async def test_non_zero_sorted_by_pieces_earned_ascending(self, service):
-        """PENDING rewards sorted by pieces_earned ascending (1, 3, 7)."""
+    async def test_pending_sorted_by_completion_ratio_descending(self, service):
+        """PENDING rewards sorted by completion ratio descending (closest-to-ready first)."""
         service.progress_repo.get_all_by_user.return_value = [
-            _make_progress(pieces_earned=7, pieces_required=10, reward_id=1),
-            _make_progress(pieces_earned=3, pieces_required=10, reward_id=2),
-            _make_progress(pieces_earned=1, pieces_required=10, reward_id=3),
+            _make_progress(pieces_earned=7, pieces_required=10, reward_id=1),  # 70%
+            _make_progress(pieces_earned=3, pieces_required=10, reward_id=2),  # 30%
+            _make_progress(pieces_earned=1, pieces_required=10, reward_id=3),  # 10%
         ]
 
         result = await service.get_user_reward_progress("1")
 
-        assert [r.reward_id for r in result] == [3, 2, 1]
+        assert [r.reward_id for r in result] == [1, 2, 3]
 
     @pytest.mark.asyncio
     async def test_achieved_appears_after_pending(self, service):
@@ -255,12 +255,12 @@ class TestGetUserRewardProgress:
 
     @pytest.mark.asyncio
     async def test_mixed_ordering_all_groups(self, service):
-        """Full ordering: zero-piece → pending (ascending by pieces_earned) → achieved; claimed excluded."""
+        """Full ordering: zero-piece → pending (descending by completion ratio) → achieved; claimed excluded."""
         service.progress_repo.get_all_by_user.return_value = [
-            _make_progress(pieces_earned=7, pieces_required=10, reward_id=1),   # pending
+            _make_progress(pieces_earned=7, pieces_required=10, reward_id=1),   # pending 70%
             _make_progress(pieces_earned=0, pieces_required=5, reward_id=2),    # zero-piece
             _make_progress(pieces_earned=10, pieces_required=10, reward_id=3),  # achieved
-            _make_progress(pieces_earned=3, pieces_required=10, reward_id=4),   # pending
+            _make_progress(pieces_earned=3, pieces_required=10, reward_id=4),   # pending 30%
             _make_progress(pieces_earned=5, pieces_required=5, claimed=True, reward_id=5),  # claimed
         ]
 
@@ -268,8 +268,8 @@ class TestGetUserRewardProgress:
 
         ids = [r.reward_id for r in result]
         # claimed (id=5) excluded; zero-piece (id=2) first;
-        # pending ascending by pieces_earned (3 → 7), then achieved last (id=3)
-        assert ids == [2, 4, 1, 3]
+        # pending descending by ratio (70% → 30%), then achieved last (id=3)
+        assert ids == [2, 1, 4, 3]
 
     @pytest.mark.asyncio
     async def test_achieved_low_pieces_after_pending_high_pieces(self, service):
@@ -339,12 +339,12 @@ class TestGetUserRewardProgress:
         assert ids == [3, 1, 2]
 
     @pytest.mark.asyncio
-    async def test_equal_pieces_earned_preserves_repo_order(self, service):
-        """Rewards with the same pieces_earned keep their repository order (stable sort)."""
+    async def test_equal_completion_ratio_preserves_repo_order(self, service):
+        """Rewards with the same completion ratio keep their repository order (stable sort)."""
         service.progress_repo.get_all_by_user.return_value = [
-            _make_progress(pieces_earned=5, pieces_required=10, reward_id=1),
-            _make_progress(pieces_earned=5, pieces_required=20, reward_id=2),
-            _make_progress(pieces_earned=5, pieces_required=7, reward_id=3),
+            _make_progress(pieces_earned=5, pieces_required=10, reward_id=1),  # 50%
+            _make_progress(pieces_earned=2, pieces_required=4, reward_id=2),   # 50%
+            _make_progress(pieces_earned=3, pieces_required=6, reward_id=3),   # 50%
         ]
 
         result = await service.get_user_reward_progress("1")
@@ -403,7 +403,7 @@ class TestGetUserRewardProgress:
 
         result = await service.get_user_reward_progress("1")
         ids = [r.reward_id for r in result]
-        # pending sorted by pieces_earned ASC: id=2 (5), id=4 (8)
+        # pending sorted by completion ratio DESC: id=2 (5/7=71%), id=4 (8/20=40%)
         # then ready_to_claim sorted by pieces_earned ASC: id=3 (5), id=1 (10)
         assert ids == [2, 4, 3, 1], (
             "Service must bucket Django-style RewardProgress correctly; "


### PR DESCRIPTION
## Why

The pending bucket was sorted by raw \`pieces_earned\` ascending. With mixed denominators, the visual progress bars zigzag:

\`\`\`
Massage 2/3       — 66%  ←  but listed first because pieces_earned=2 is smallest
Coffee 5/7        — 71%
LV Imagination 8/20 — 40%  ← drops back to 40%
Rolex 9/30        — 30%
YSL 15/50         — 30%
iPad 24/50        — 48%  ← jumps up to 48%
\`\`\`

## Change

Sort pending by completion ratio (\`pieces_earned / pieces_required\`) descending — closest-to-ready first — so progress bars decrease monotonically down the list and flow naturally into the ready-to-claim bucket below:

\`\`\`
Coffee 5/7       — 71%
Massage 2/3      — 66%
iPad 24/50       — 48%
LV Imagination 8/20 — 40%
Rolex 9/30       — 30%
YSL 15/50        — 30%
─── ready bucket below ───
\`\`\`

## Implementation

- Extracts \`_resolve_pieces_required\` as a static helper (was inline in the bucketing loop in #53; now also used by the pending sort key) — avoids duplicating Django-vs-Pydantic model resolution.
- Sort key: \`-(rp.pieces_earned / pieces_req)\` (negative for descending; pending items always have non-zero pieces_req or they'd be in the zero-piece bucket).
- Ready-to-claim sort unchanged (still \`pieces_earned\` ASC — all are 100% so ratio is meaningless).

## Test changes

- Rename + retarget: \`test_non_zero_sorted_by_pieces_earned_ascending\` → \`test_pending_sorted_by_completion_ratio_descending\`
- Update \`test_mixed_ordering_all_groups\` expected order (pending 70% then 30% instead of pieces_earned 3 then 7)
- Rename + rewrite: \`test_equal_pieces_earned_preserves_repo_order\` → \`test_equal_completion_ratio_preserves_repo_order\` (fixture now uses three items with 50% ratio but different denominators, since equal pieces_earned with different denominators no longer means equal sort keys)

\`uv run pytest tests/test_reward_filtering.py\` — 21/21 pass.

## Verification plan
- [ ] After deploy, Playwright login → /rewards/ → inspect order: pending bucket should run from highest % down to lowest %

🤖 Generated with [Claude Code](https://claude.com/claude-code)