### PR TITLE
feat: sidebar Today icon stays green when inactive

### DIFF
--- a/frontend/src/components/Layout.vue
+++ b/frontend/src/components/Layout.vue
@@ -61,7 +61,7 @@
           class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150"
           :class="sidebarNavItemClass(item.href)"
         >
-          <span class="text-lg">{{ item.icon }}</span>
+          <span class="text-lg" :class="sidebarIconClass(item.href)">{{ item.icon }}</span>
           {{ item.label }}
         </Link>
       </nav>
@@ -129,6 +129,13 @@ const sidebarClass = computed(() => {
   }
   return "bg-bg-card border-gray-800";
 });
+
+function sidebarIconClass(href) {
+  // Today's ✔ icon reads green when inactive — signals "mark complete"
+  // before the user navigates in, instead of inheriting muted gray.
+  if (href === "/" && !isActive(href)) return "text-emerald-500";
+  return "";
+}
 
 function sidebarNavItemClass(href) {
   const active = isActive(href);


### PR DESCRIPTION
## Change
The Today ✔ icon in the desktop sidebar currently inherits the inactive nav item's muted gray text. Tint it `text-emerald-500` when the user is on another page so the entry point reads as actionable from anywhere. Active state still uses the theme accent (no change).

Only touches the desktop sidebar (Layout.vue), not the top-bar layout or the mobile bottom nav.

## Test plan
- [ ] Open https://habitreward.org/rewards/ — sidebar Today icon should be green
- [ ] Click Today → on the Today page, icon switches back to accent color (active highlight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)