### PR TITLE
feat(security): split CSP style-src into -elem/-attr (#24)

### DIFF
--- a/docs/features/0045_PLAN.md
+++ b/docs/features/0045_PLAN.md
@@ -1,0 +1,150 @@
+# 0045 — Tighten CSP: split `style-src` into `-elem` and `-attr`
+
+Partial resolution for [GitHub issue #24](https://github.com/erzhan12/habit-reward/issues/24).
+
+## Context
+
+The production Content-Security-Policy currently uses:
+
+```
+style-src 'self' 'nonce-{nonce}' 'unsafe-inline' https://fonts.googleapis.com
+```
+
+`'unsafe-inline'` is the loophole that lets an XSS payload inject arbitrary `<style>` blocks (e.g. `<style>@import url(evil)</style>` for data exfiltration) or arbitrary `style="..."` attributes.
+
+Fully removing `'unsafe-inline'` is blocked because:
+1. Vue 3 has 14+ `:style="..."` bindings (e.g. progress bars, swipe gestures, entrance animations) that compile to inline `style=""` attributes on elements.
+2. There is no nonce mechanism for HTML inline style **attributes**.
+
+However, CSP Level 3 allows splitting `style-src` into:
+- `style-src-elem` — controls `<style>` blocks and `<link rel="stylesheet">`
+- `style-src-attr` — controls inline `style="..."` HTML attributes
+
+This lets us **strictly lock down `<style>` blocks via nonce** while still allowing dynamic `:style` bindings via `'unsafe-inline'` on attributes only. This is a meaningful XSS hardening in modern CSP3 browsers (Chrome 75+, Firefox 109+, Safari 15.4+): the most dangerous injection vector (`<style>@import ...</style>`) is closed there.
+
+**Residual risk**: older browsers fall back to the legacy `style-src` directive (which still includes `'unsafe-inline'` for backward compatibility) and remain vulnerable to inline `<style>` injection. Fully closing the vector everywhere requires dropping the legacy fallback — a follow-up once telemetry shows old-browser traffic is negligible.
+
+## Scope
+
+Update CSP middleware to emit `style-src-elem` and `style-src-attr` instead of a unified `style-src`. Verify Vue 3 production bundle does not inject runtime `<style>` tags so the strict `-elem` policy does not break the app.
+
+## Files to change
+
+### `src/web/middleware.py`
+
+- Update `ContentSecurityPolicyMiddleware._CSP_TEMPLATE`:
+  - Remove the single `style-src 'self' 'nonce-{nonce}' 'unsafe-inline' https://fonts.googleapis.com` line.
+  - Add `style-src-elem 'self' 'nonce-{nonce}' https://fonts.googleapis.com` (no `'unsafe-inline'`).
+  - Add `style-src-attr 'unsafe-inline'` (still required for Vue `:style` bindings).
+  - Keep a fallback `style-src 'self' 'nonce-{nonce}' 'unsafe-inline' https://fonts.googleapis.com` for older browsers that do not understand `-elem` / `-attr` (CSP directives fall through to `style-src` when unknown). Document this as a back-compat fallback.
+- Update the docstring on the class to reflect the new directive split and the partial-fix status of issue #24.
+- Update the inline `TODO(#24)` comment to point out remaining work: eliminate `:style` bindings to also drop `style-src-attr 'unsafe-inline'`.
+
+### `src/templates/base.html`
+
+- No code change required. The `<meta name="csp-nonce" content="{{ csp_nonce }}">` tag continues to expose the nonce to the frontend. Verify it is still rendered in the production HTML.
+
+### `src/web/context_processors.py`
+
+- No change. `csp_nonce` context processor still works unchanged.
+
+### `frontend/vite.config.js`
+
+- No change. Existing build already extracts CSS into a hashed asset listed under `css` in `frontend/dist/manifest.json` (verify the manifest entry for `src/main.js` contains a non-empty `css` array). No runtime `<style>` injection in production — CSS is loaded via `<link rel="stylesheet">`.
+
+## Algorithm / Behavior
+
+1. Per-request `csp_nonce` generation is unchanged (`secrets.token_urlsafe(16)` in `__call__`).
+2. When `settings.DEBUG` is `False`, the response receives:
+   - `style-src 'self' 'nonce-<nonce>' 'unsafe-inline' https://fonts.googleapis.com` (legacy fallback)
+   - `style-src-elem 'self' 'nonce-<nonce>' https://fonts.googleapis.com` (strict — modern browsers)
+   - `style-src-attr 'unsafe-inline'` (permissive — for Vue `:style` bindings)
+3. Browser behavior:
+   - Modern browsers (Chrome 75+, Firefox 109+, Safari 15.4+) honor `-elem` and `-attr`, ignore `style-src` for styles.
+   - Older browsers fall back to `style-src` (unchanged from current).
+4. The Vite-built CSS asset is referenced from the HTML via `<link rel="stylesheet" href="/static/...">` — covered by `style-src-elem 'self'`.
+5. Google Fonts stylesheet (`fonts.googleapis.com`) — covered by allowlist in `-elem`.
+6. Any Django template `<style nonce="{{ csp_nonce }}">` block — covered by `'nonce-<nonce>'` in `-elem`.
+7. Vue `:style="..."` bindings rendering inline `style=""` attrs — covered by `'unsafe-inline'` in `-attr`.
+
+## Unit tests
+
+Create `tests/web/test_csp_middleware.py` to match the existing package layout (other middleware tests live under `tests/web/`, e.g. `tests/web/test_middleware.py`).
+
+Use Django's `RequestFactory` and a stub `get_response` callable to invoke `ContentSecurityPolicyMiddleware` directly.
+
+### Test helpers
+
+Add a `_parse_csp(header_value: str) -> dict[str, list[str]]` helper at the top of the test module:
+- Split the header on `;`, strip whitespace, then split each directive on the first run of whitespace.
+- Return a dict mapping directive name → list of source-expression tokens.
+- All directive assertions in the tests below MUST use this parsed dict and key by directive name. Do **not** use raw substring matching on the header string — `style-src` is a prefix of `style-src-elem` and `style-src-attr`, so `'style-src' in header` would match the split directives and produce false positives.
+
+### Settings overrides for production-mode tests
+
+Tests that exercise production behavior must override both `DEBUG` **and** `DJANGO_VITE['default']['dev_mode']`, because [src/habit_reward_project/settings.py:316-318](src/habit_reward_project/settings.py#L316-L318) initializes `DJANGO_VITE['default']['dev_mode']` from `DEBUG` at import time. Overriding only `DEBUG` leaves Vite in dev mode, so any test that asserts production HTML asset rendering (e.g. the `<link rel="stylesheet">` covering `style-src-elem 'self'`) would not actually exercise the production path.
+
+Apply via `@override_settings` with the full dict (the `...` shorthand is not valid Python — copying it into a decorator will raise `SyntaxError`):
+
+```python
+@override_settings(
+    DEBUG=False,
+    DJANGO_VITE={
+        "default": {
+            "dev_mode": False,
+            "dev_server_host": "localhost",
+            "dev_server_port": 5173,
+        }
+    },
+)
+```
+
+Or use an equivalent pytest fixture. Pure middleware-only tests that do not render templates may override only `DEBUG`.
+
+### Test scenarios
+
+1. **`test_csp_header_set_in_production`**
+   - With `settings.DEBUG = False`, response includes `Content-Security-Policy` header.
+
+2. **`test_csp_header_absent_in_debug`**
+   - With `settings.DEBUG = True`, response does NOT include `Content-Security-Policy` header (preserves Vite HMR).
+
+3. **`test_csp_includes_style_src_elem_with_nonce`**
+   - In production mode, header contains `style-src-elem 'self' 'nonce-<value>' https://fonts.googleapis.com`.
+   - Nonce in directive matches `request.csp_nonce`.
+   - Verify `'unsafe-inline'` is NOT present in `style-src-elem`.
+
+4. **`test_csp_includes_style_src_attr_with_unsafe_inline`**
+   - In production mode, header contains `style-src-attr 'unsafe-inline'`.
+
+5. **`test_csp_legacy_style_src_fallback`**
+   - In production mode, header contains the legacy `style-src` directive with `'self'`, nonce, `'unsafe-inline'`, and Google Fonts allowlist (for old-browser fallback).
+
+6. **`test_csp_nonce_is_unique_per_request`**
+   - Two sequential requests produce two different nonces in the header.
+
+7. **`test_csp_nonce_attached_to_request`**
+   - After middleware runs, `request.csp_nonce` is a non-empty string of expected token length.
+
+8. **`test_other_security_headers_set`**
+   - `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin` all present in production.
+
+9. **`test_template_meta_nonce_matches_csp_header`** (integration-level, uses Django `Client`)
+   - Override `DEBUG=False` **and** `DJANGO_VITE['default']['dev_mode']=False` (see "Settings overrides" above) so the rendered HTML reflects production asset loading.
+   - Issue an authenticated GET against a page that renders `base.html`.
+   - Parse the response body and extract the `content` attribute of `<meta name="csp-nonce" ...>` — this is the **raw** nonce, e.g. `abc123`.
+   - Use `_parse_csp` on the response's `Content-Security-Policy` header; locate the source token in the `style-src-elem` directive that starts with `'nonce-`. **Normalize it** by stripping the surrounding single quotes and the `nonce-` prefix (e.g. `'nonce-abc123'` → `abc123`) before comparison.
+   - Assert the normalized CSP nonce equals the meta-tag nonce — confirms the context processor and middleware share the same per-request nonce.
+
+### Edge cases
+
+- `script-src`, `default-src`, `font-src`, `img-src`, `connect-src` directives remain present and unchanged — assert their values do not regress.
+- The CSP string is a single header with directives separated by `;` — assert format integrity (no stray newlines or commas).
+
+## Manual verification
+
+After deployment:
+1. Load `habitreward.org` in Chrome DevTools → Network → check response headers for the new directive split.
+2. Open Console — verify no CSP violation errors when navigating Today, Rewards, Streaks, History, Analytics pages (all have entrance animations using `:style` bindings).
+3. Trigger a habit completion swipe — `:style="{ transform: ... }"` binding should still work without violation.
+4. Try injecting `<style>body{background:red}</style>` into a habit name field (if input allows) — expect CSP violation in console, style not applied.

--- a/src/web/context_processors.py
+++ b/src/web/context_processors.py
@@ -4,12 +4,13 @@
 def csp_nonce(request):
     """Make the CSP nonce available as ``{{ csp_nonce }}`` in templates.
 
-    When a Content-Security-Policy middleware (e.g. django-csp) is active,
-    it attaches a per-request nonce to ``request.csp_nonce``.  This context
-    processor exposes that value so templates can allowlist inline scripts
-    and styles without resorting to ``'unsafe-inline'``.
+    Reads the per-request nonce attached by
+    :class:`src.web.middleware.ContentSecurityPolicyMiddleware` so
+    templates can allowlist inline scripts and styles without resorting
+    to ``'unsafe-inline'``.
 
-    If no CSP middleware is installed, returns an empty string (no-op).
+    If the middleware did not run (e.g. tests bypassing the stack),
+    returns an empty string (no-op).
 
     Usage in a Django template::
 

--- a/src/web/middleware.py
+++ b/src/web/middleware.py
@@ -64,27 +64,37 @@ class ContentSecurityPolicyMiddleware:
     In production (DEBUG=False), applies a strict CSP and security headers.
     In development, skips these headers to allow Vite HMR.
 
-    A per-request nonce replaces the old ``'unsafe-inline'`` for style-src.
-    The nonce is stored on ``request.csp_nonce`` and made available in
-    templates via the ``csp_nonce`` context processor.
+    A per-request nonce, stored on ``request.csp_nonce`` and exposed to
+    templates via the ``csp_nonce`` context processor, locks down
+    ``<style>`` blocks and ``<link rel="stylesheet">`` references.
 
-    Note: Vue 3 runtime style injection (scoped component styles) may still
-    require ``'unsafe-inline'`` as a fallback until Vue adds native nonce
-    support for injected ``<style>`` tags.  The nonce covers any inline
-    styles in Django templates and manually authored ``<style>`` blocks.
+    Partial resolution of issue #24: ``style-src`` is split into
+    ``style-src-elem`` (strict — no ``'unsafe-inline'``) and
+    ``style-src-attr`` (still ``'unsafe-inline'`` for Vue ``:style``
+    bindings).  A legacy ``style-src`` directive is kept as a fallback
+    for older browsers that do not understand the split directives —
+    those browsers ignore the unknown ``-elem``/``-attr`` directives
+    and fall back to ``style-src``, which retains ``'unsafe-inline'``
+    for backward compatibility.  Modern browsers (Chrome 75+, Firefox
+    109+, Safari 15.4+) honor the strict split and ignore the legacy
+    directive.  See https://github.com/erzhan12/habit-reward/issues/24.
     """
 
     # Template with {nonce} placeholder, filled per-request.
     _CSP_TEMPLATE = "; ".join([
         "default-src 'self'",
         "script-src 'self'",
-        # 'unsafe-inline' is needed for Vue 3 scoped styles which inject
-        # <style> tags at runtime without nonce support.  The nonce still
-        # covers Django template styles and manually authored blocks.
-        # TODO(#24): Remove 'unsafe-inline' from style-src once Vue 3 build
-        # pipeline supports nonce injection for scoped styles.  Investigate
-        # vite-plugin-css-injected-by-js or similar solutions.
-        # See: https://github.com/erzhan12/habit-reward/issues/24
+        # Strict <style> / <link rel=stylesheet> policy: nonce + allowlist,
+        # no 'unsafe-inline'.  Honored by modern CSP3 browsers.
+        "style-src-elem 'self' 'nonce-{nonce}' https://fonts.googleapis.com",
+        # Permissive inline style="..." attribute policy for Vue :style
+        # bindings.  TODO(#24): eliminate :style bindings so we can drop
+        # 'unsafe-inline' here too.
+        "style-src-attr 'unsafe-inline'",
+        # Legacy fallback for browsers that do not honor style-src-elem /
+        # style-src-attr (pre-CSP3).  Those browsers fall through to this
+        # directive, which keeps 'unsafe-inline' so the app still renders.
+        # TODO(#24): drop once old-browser traffic is negligible.
         "style-src 'self' 'nonce-{nonce}' 'unsafe-inline' https://fonts.googleapis.com",
         "font-src 'self' https://fonts.gstatic.com",
         "img-src 'self' data: https:",

--- a/tests/web/test_csp_middleware.py
+++ b/tests/web/test_csp_middleware.py
@@ -7,13 +7,39 @@ Verifies the split-directive CSP policy: strict ``style-src-elem`` for
 directives.
 """
 
-import re
+from html.parser import HTMLParser
 
 import pytest
 from django.http import HttpResponse
 from django.test import Client, RequestFactory, override_settings
 
 from src.web.middleware import ContentSecurityPolicyMiddleware
+
+
+class _CSPNonceMetaExtractor(HTMLParser):
+    """Extract the ``content`` of ``<meta name="csp-nonce">`` from HTML.
+
+    Robust against attribute-order changes in ``base.html`` — using a
+    real HTML parser instead of a regex avoids false negatives if the
+    template is reformatted.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.nonce: str | None = None
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "meta":
+            return
+        attr_map = dict(attrs)
+        if attr_map.get("name") == "csp-nonce":
+            self.nonce = attr_map.get("content")
+
+
+def _extract_csp_nonce_meta(html: str) -> str | None:
+    parser = _CSPNonceMetaExtractor()
+    parser.feed(html)
+    return parser.nonce
 
 
 # -----------------------------------------------------------------------------
@@ -215,18 +241,18 @@ class TestCSPNonceTemplateIntegration:
         same per-request nonce.
 
         Uses ``/auth/login/`` because it renders ``base.html`` without
-        requiring authentication or heavy view-layer mocks.
+        requiring authentication or heavy view-layer mocks.  If
+        ``/auth/login/`` is ever removed or stops rendering ``base.html``,
+        replace this fixture with another unauthenticated endpoint that
+        does — or add a minimal test-only view in ``tests/web/conftest.py``.
         """
         response = Client().get("/auth/login/")
         assert response.status_code == 200
         assert "Content-Security-Policy" in response
 
         body = response.content.decode("utf-8")
-        match = re.search(
-            r'<meta\s+name="csp-nonce"\s+content="([^"]*)"', body
-        )
-        assert match is not None, "csp-nonce meta tag not found in response"
-        meta_nonce = match.group(1)
+        meta_nonce = _extract_csp_nonce_meta(body)
+        assert meta_nonce is not None, "csp-nonce meta tag not found in response"
         assert meta_nonce, "csp-nonce meta tag has empty content"
 
         parsed = _parse_csp(response["Content-Security-Policy"])

--- a/tests/web/test_csp_middleware.py
+++ b/tests/web/test_csp_middleware.py
@@ -1,0 +1,239 @@
+"""Tests for ContentSecurityPolicyMiddleware (issue #24).
+
+Verifies the split-directive CSP policy: strict ``style-src-elem`` for
+``<style>`` blocks (no ``'unsafe-inline'``), permissive
+``style-src-attr`` for Vue ``:style`` bindings, and a legacy
+``style-src`` fallback for browsers that do not support the split
+directives.
+"""
+
+import re
+
+import pytest
+from django.http import HttpResponse
+from django.test import Client, RequestFactory, override_settings
+
+from src.web.middleware import ContentSecurityPolicyMiddleware
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _parse_csp(header_value: str) -> dict[str, list[str]]:
+    """Parse a Content-Security-Policy header into ``{directive: [tokens]}``.
+
+    Split the header on ``;``, strip whitespace, then split each directive
+    on its first run of whitespace.  Directive names are returned as-is.
+
+    All directive lookups MUST use this parsed dict, never substring matches
+    on the raw header — ``style-src`` is a prefix of ``style-src-elem`` and
+    ``style-src-attr``, so ``'style-src' in header`` produces false positives.
+    """
+    parsed: dict[str, list[str]] = {}
+    for directive in header_value.split(";"):
+        directive = directive.strip()
+        if not directive:
+            continue
+        parts = directive.split(None, 1)
+        name = parts[0]
+        tokens = parts[1].split() if len(parts) > 1 else []
+        parsed[name] = tokens
+    return parsed
+
+
+def _ok_response(request):
+    """Stub get_response returning a 200 OK."""
+    return HttpResponse("ok")
+
+
+def _run_middleware(request):
+    """Invoke ContentSecurityPolicyMiddleware against ``request`` directly."""
+    middleware = ContentSecurityPolicyMiddleware(_ok_response)
+    return middleware(request)
+
+
+# Production-mode settings override: DEBUG=False AND
+# DJANGO_VITE['default']['dev_mode']=False.  See
+# src/habit_reward_project/settings.py:316-322 — DJANGO_VITE['default']
+# ['dev_mode'] is initialized from DEBUG at import time, so overriding
+# only DEBUG leaves Vite in dev mode and integration tests that render
+# base.html will not exercise the production asset path.
+_PRODUCTION_SETTINGS = dict(
+    DEBUG=False,
+    DJANGO_VITE={
+        "default": {
+            "dev_mode": False,
+            "dev_server_host": "localhost",
+            "dev_server_port": 5173,
+        }
+    },
+)
+
+
+# -----------------------------------------------------------------------------
+# Unit tests — drive the middleware directly with RequestFactory
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestContentSecurityPolicyMiddleware:
+    """Direct unit tests for the CSP middleware.
+
+    These tests do not render templates, so overriding ``DEBUG`` alone is
+    sufficient — they do not exercise ``django_vite``.
+    """
+
+    def setup_method(self):
+        self.factory = RequestFactory()
+
+    @override_settings(DEBUG=False)
+    def test_csp_header_set_in_production(self):
+        request = self.factory.get("/")
+        response = _run_middleware(request)
+        assert "Content-Security-Policy" in response
+
+    @override_settings(DEBUG=True)
+    def test_csp_header_absent_in_debug(self):
+        request = self.factory.get("/")
+        response = _run_middleware(request)
+        assert "Content-Security-Policy" not in response
+
+    @override_settings(DEBUG=False)
+    def test_csp_includes_style_src_elem_with_nonce(self):
+        request = self.factory.get("/")
+        response = _run_middleware(request)
+        parsed = _parse_csp(response["Content-Security-Policy"])
+
+        assert "style-src-elem" in parsed
+        tokens = parsed["style-src-elem"]
+        assert "'self'" in tokens
+        assert "https://fonts.googleapis.com" in tokens
+        # Strict: no 'unsafe-inline' on -elem.
+        assert "'unsafe-inline'" not in tokens
+        # Nonce token must match the request nonce.
+        nonce_tokens = [t for t in tokens if t.startswith("'nonce-")]
+        assert len(nonce_tokens) == 1
+        # Strip "'nonce-" prefix and trailing "'".
+        nonce_value = nonce_tokens[0][len("'nonce-") : -1]
+        assert nonce_value == request.csp_nonce
+
+    @override_settings(DEBUG=False)
+    def test_csp_includes_style_src_attr_with_unsafe_inline(self):
+        request = self.factory.get("/")
+        response = _run_middleware(request)
+        parsed = _parse_csp(response["Content-Security-Policy"])
+
+        assert "style-src-attr" in parsed
+        assert parsed["style-src-attr"] == ["'unsafe-inline'"]
+
+    @override_settings(DEBUG=False)
+    def test_csp_legacy_style_src_fallback(self):
+        request = self.factory.get("/")
+        response = _run_middleware(request)
+        parsed = _parse_csp(response["Content-Security-Policy"])
+
+        assert "style-src" in parsed
+        tokens = parsed["style-src"]
+        assert "'self'" in tokens
+        assert "'unsafe-inline'" in tokens
+        assert "https://fonts.googleapis.com" in tokens
+        nonce_tokens = [t for t in tokens if t.startswith("'nonce-")]
+        assert len(nonce_tokens) == 1
+
+    @override_settings(DEBUG=False)
+    def test_csp_nonce_is_unique_per_request(self):
+        request1 = self.factory.get("/")
+        response1 = _run_middleware(request1)
+        request2 = self.factory.get("/")
+        response2 = _run_middleware(request2)
+
+        parsed1 = _parse_csp(response1["Content-Security-Policy"])
+        parsed2 = _parse_csp(response2["Content-Security-Policy"])
+
+        nonce1 = next(t for t in parsed1["style-src-elem"] if t.startswith("'nonce-"))
+        nonce2 = next(t for t in parsed2["style-src-elem"] if t.startswith("'nonce-"))
+        assert nonce1 != nonce2
+
+    @override_settings(DEBUG=False)
+    def test_csp_nonce_attached_to_request(self):
+        request = self.factory.get("/")
+        _run_middleware(request)
+        # secrets.token_urlsafe(16) → 22-char base64-url string.
+        assert isinstance(request.csp_nonce, str)
+        assert len(request.csp_nonce) >= 16
+
+    @override_settings(DEBUG=False)
+    def test_other_security_headers_set(self):
+        request = self.factory.get("/")
+        response = _run_middleware(request)
+        assert response["X-Content-Type-Options"] == "nosniff"
+        assert response["X-Frame-Options"] == "DENY"
+        assert response["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
+    @override_settings(DEBUG=False)
+    def test_unchanged_directives_remain_present(self):
+        """Other CSP directives must not regress."""
+        request = self.factory.get("/")
+        response = _run_middleware(request)
+        parsed = _parse_csp(response["Content-Security-Policy"])
+
+        assert parsed["default-src"] == ["'self'"]
+        assert parsed["script-src"] == ["'self'"]
+        assert parsed["font-src"] == ["'self'", "https://fonts.gstatic.com"]
+        assert parsed["img-src"] == ["'self'", "data:", "https:"]
+        assert parsed["connect-src"] == ["'self'"]
+
+    @override_settings(DEBUG=False)
+    def test_csp_header_format_integrity(self):
+        """Header is a single line, directives separated by ``;``."""
+        request = self.factory.get("/")
+        response = _run_middleware(request)
+        header = response["Content-Security-Policy"]
+        assert "\n" not in header
+        assert "\r" not in header
+        # Directive separator is ``;`` — there must be no stray commas
+        # outside of source-expression values (none of which use commas).
+        assert "," not in header
+
+
+# -----------------------------------------------------------------------------
+# Integration test — exercises the full template rendering pipeline
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCSPNonceTemplateIntegration:
+    """End-to-end check that meta-tag nonce equals CSP-header nonce."""
+
+    @override_settings(**_PRODUCTION_SETTINGS)
+    def test_template_meta_nonce_matches_csp_header(self):
+        """The ``<meta name="csp-nonce">`` value in the rendered HTML
+        must equal the nonce embedded in the ``style-src-elem`` CSP
+        directive — confirms middleware and context processor share the
+        same per-request nonce.
+
+        Uses ``/auth/login/`` because it renders ``base.html`` without
+        requiring authentication or heavy view-layer mocks.
+        """
+        response = Client().get("/auth/login/")
+        assert response.status_code == 200
+        assert "Content-Security-Policy" in response
+
+        body = response.content.decode("utf-8")
+        match = re.search(
+            r'<meta\s+name="csp-nonce"\s+content="([^"]*)"', body
+        )
+        assert match is not None, "csp-nonce meta tag not found in response"
+        meta_nonce = match.group(1)
+        assert meta_nonce, "csp-nonce meta tag has empty content"
+
+        parsed = _parse_csp(response["Content-Security-Policy"])
+        elem_tokens = parsed["style-src-elem"]
+        nonce_token = next(t for t in elem_tokens if t.startswith("'nonce-"))
+        # Normalize: strip surrounding quotes and the ``nonce-`` prefix.
+        # E.g. "'nonce-abc123'" → "abc123".
+        header_nonce = nonce_token.strip("'")[len("nonce-") :]
+
+        assert header_nonce == meta_nonce


### PR DESCRIPTION
## Summary
- Splits `style-src` into `style-src-elem` (strict — no `'unsafe-inline'`, just nonce + Google Fonts) and `style-src-attr 'unsafe-inline'` (for Vue 3 `:style` bindings) — partial resolution of #24.
- Keeps a legacy `style-src` directive as a fallback for pre-CSP3 browsers; closes the `<style>@import url(evil)</style>` XSS vector on modern browsers (Chrome 75+, Firefox 109+, Safari 15.4+).
- Adds `tests/web/test_csp_middleware.py` (11 tests: directive split, per-request nonce uniqueness, template ↔ header nonce parity, regression guards on `default-src` / `script-src` / `font-src` / `img-src` / `connect-src`).

## Test plan
- [x] `uv run pytest tests/web/test_csp_middleware.py -v` → 11 passed
- [x] `uv run pytest tests/web/ -v` → 281 passed (no regressions)
- [ ] After deploy to habitreward.org: DevTools → Network → confirm `Content-Security-Policy` header contains all three directives (`style-src-elem`, `style-src-attr`, legacy `style-src`).
- [ ] After deploy: navigate Today / Rewards / Streaks / History / Analytics — no CSP violations in Console (entrance animations use `:style`).
- [ ] After deploy: trigger habit completion swipe — `:style="{ transform: ... }"` works without violation.

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)