### PR TITLE
fix(csp): bundle nprogress CSS so it loads via <link> (#24 follow-up)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./animations.css";
+@import "./nprogress.css";
 
 /* =========================================================
    Default theme variables (Clean Modern)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -34,6 +34,11 @@ router.on("before", (event) => {
 });
 
 createInertiaApp({
+  // Inertia's nprogress loader would otherwise document.head.appendChild
+  // a <style> block at runtime with no nonce — blocked by our strict CSP
+  // (style-src-elem: nonce + allowlist, no 'unsafe-inline').  Ship the
+  // same CSS bundled via app.css instead — see frontend/src/nprogress.css.
+  progress: { includeCSS: false },
   resolve: (name) => {
     const pages = import.meta.glob("./pages/**/*.vue", { eager: true });
     const page = pages[`./pages/${name}.vue`];

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -38,6 +38,7 @@ createInertiaApp({
   // a <style> block at runtime with no nonce — blocked by our strict CSP
   // (style-src-elem: nonce + allowlist, no 'unsafe-inline').  Ship the
   // same CSS bundled via app.css instead — see frontend/src/nprogress.css.
+  // The `includeCSS` option requires @inertiajs/vue3 >= 2.0.0.
   progress: { includeCSS: false },
   resolve: (name) => {
     const pages = import.meta.glob("./pages/**/*.vue", { eager: true });

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -34,11 +34,8 @@ router.on("before", (event) => {
 });
 
 createInertiaApp({
-  // Inertia's nprogress loader would otherwise document.head.appendChild
-  // a <style> block at runtime with no nonce — blocked by our strict CSP
-  // (style-src-elem: nonce + allowlist, no 'unsafe-inline').  Ship the
-  // same CSS bundled via app.css instead — see frontend/src/nprogress.css.
-  // The `includeCSS` option requires @inertiajs/vue3 >= 2.0.0.
+  // Disable nprogress's runtime <style> injection (blocked by our CSP);
+  // bundled in app.css instead.  Requires @inertiajs/vue3 >= 2.0.0.
   progress: { includeCSS: false },
   resolve: (name) => {
     const pages = import.meta.glob("./pages/**/*.vue", { eager: true });

--- a/frontend/src/nprogress.css
+++ b/frontend/src/nprogress.css
@@ -11,8 +11,6 @@
  *
  * Verbatim copy of nprogress 0.2.0 defaults — colour #29d, 2px bar at
  * top, spinner top-right — to match prior visual behaviour exactly.
- * If we ever want to theme the bar per app theme, replace #29d with
- * var(--color-accent).
  */
 
 #nprogress {

--- a/frontend/src/nprogress.css
+++ b/frontend/src/nprogress.css
@@ -1,0 +1,80 @@
+/*
+ * Bundled nprogress styling for the Inertia.js page-load progress bar.
+ *
+ * Originally injected at runtime by @inertiajs/vue3 via
+ * document.head.appendChild(<style>...) without a CSP nonce.  Our
+ * strict CSP (style-src-elem: 'self' 'nonce-...' — no 'unsafe-inline')
+ * blocks the runtime injection, so we disable it by passing
+ *   progress: { includeCSS: false }
+ * to createInertiaApp() (see main.js) and ship the same rules here,
+ * loaded via <link rel="stylesheet"> through the Vite bundle.
+ *
+ * Verbatim copy of nprogress 0.2.0 defaults — colour #29d, 2px bar at
+ * top, spinner top-right — to match prior visual behaviour exactly.
+ * If we ever want to theme the bar per app theme, replace #29d with
+ * var(--color-accent).
+ */
+
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  background: #29d;
+
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 2px;
+}
+
+#nprogress .peg {
+  display: block;
+  position: absolute;
+  right: 0px;
+  width: 100px;
+  height: 100%;
+  box-shadow: 0 0 10px #29d, 0 0 5px #29d;
+  opacity: 1.0;
+
+  transform: rotate(3deg) translate(0px, -4px);
+}
+
+#nprogress .spinner {
+  display: block;
+  position: fixed;
+  z-index: 1031;
+  top: 15px;
+  right: 15px;
+}
+
+#nprogress .spinner-icon {
+  width: 18px;
+  height: 18px;
+  box-sizing: border-box;
+
+  border: solid 2px transparent;
+  border-top-color: #29d;
+  border-left-color: #29d;
+  border-radius: 50%;
+
+  animation: nprogress-spinner 400ms linear infinite;
+}
+
+.nprogress-custom-parent {
+  overflow: hidden;
+  position: relative;
+}
+
+.nprogress-custom-parent #nprogress .spinner,
+.nprogress-custom-parent #nprogress .bar {
+  position: absolute;
+}
+
+@keyframes nprogress-spinner {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/frontend/src/nprogress.css
+++ b/frontend/src/nprogress.css
@@ -1,17 +1,5 @@
-/*
- * Bundled nprogress styling for the Inertia.js page-load progress bar.
- *
- * Originally injected at runtime by @inertiajs/vue3 via
- * document.head.appendChild(<style>...) without a CSP nonce.  Our
- * strict CSP (style-src-elem: 'self' 'nonce-...' — no 'unsafe-inline')
- * blocks the runtime injection, so we disable it by passing
- *   progress: { includeCSS: false }
- * to createInertiaApp() (see main.js) and ship the same rules here,
- * loaded via <link rel="stylesheet"> through the Vite bundle.
- *
- * Verbatim copy of nprogress 0.2.0 defaults — colour #29d, 2px bar at
- * top, spinner top-right — to match prior visual behaviour exactly.
- */
+/* Verbatim nprogress 0.2.0 CSS — bundled so the strict style-src-elem
+   CSP blocks the runtime injection from @inertiajs/vue3.  See main.js. */
 
 #nprogress {
   pointer-events: none;

--- a/scripts/csp-smoke/.gitignore
+++ b/scripts/csp-smoke/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/scripts/csp-smoke/README.md
+++ b/scripts/csp-smoke/README.md
@@ -27,6 +27,13 @@ node run.mjs                                      # defaults to https://habitrew
 node run.mjs https://staging.example.com/auth/login/
 ```
 
+> **Note:** This is a *post-deploy* verification tool that hits a live URL —
+> it is intentionally **not** wired into pre-merge CI.  CSP correctness
+> depends on the actual served response headers and the bundled assets
+> as they ship, neither of which can be exercised at unit-test time
+> against a Django test client.  For pre-deploy checks against a
+> staging environment, pass the staging URL as the first argument.
+
 Asserts:
 
 1. Page loads with HTTP 200.

--- a/scripts/csp-smoke/README.md
+++ b/scripts/csp-smoke/README.md
@@ -1,0 +1,80 @@
+# csp-smoke
+
+Playwright-based smoke tests for the production Content-Security-Policy
+on habitreward.org. Created during the rollout of [issue #24][issue-24]
+(splitting `style-src` into strict `style-src-elem` and permissive
+`style-src-attr`).
+
+[issue-24]: https://github.com/erzhan12/habit-reward/issues/24
+
+## Setup
+
+```bash
+cd scripts/csp-smoke
+npm install        # installs playwright 1.55
+npx playwright install chromium   # one-time browser download (~80 MB)
+```
+
+## Scripts
+
+### `run.mjs` — main smoke test
+
+Run **after every production deploy** that touches the CSP middleware,
+the Vue/Inertia frontend, or the `<base.html>` template.
+
+```bash
+node run.mjs                                      # defaults to https://habitreward.org/auth/login/
+node run.mjs https://staging.example.com/auth/login/
+```
+
+Asserts:
+
+1. Page loads with HTTP 200.
+2. `style-src-elem` directive is present and contains `'self'`,
+   `'nonce-...'`, and `https://fonts.googleapis.com`.
+3. `style-src-elem` does NOT contain `'unsafe-inline'` (strict policy).
+4. `style-src-attr 'unsafe-inline'` is present (Vue `:style` bindings).
+5. Legacy `style-src` fallback is present (pre-CSP3 browsers).
+6. `<meta name="csp-nonce">` matches the nonce embedded in the
+   `style-src-elem` header — confirms middleware + context processor
+   share the same per-request value.
+7. **Negative probe** — a JS-injected `<style>` block without a nonce
+   triggers a `securitypolicyviolation` (XSS vector closed).
+8. **Positive probe** — `element.style.*` assignment does NOT violate
+   (Vue `:style="..."` bindings would otherwise break).
+9. Surfaces any other console errors on the page (a non-zero count is a
+   regression — e.g. a third-party library injecting unnonced styles,
+   like the `nprogress` regression that motivated PR #57).
+
+Exit code 0 = all PASS; non-zero = at least one FAIL.
+
+### `diagnose-injections.mjs` — debugging aid
+
+Use when `run.mjs` reports CSP console errors and you need to find what
+JavaScript is injecting them. Patches `appendChild` / `insertBefore` to
+log every `<style>` insertion with a stack trace.
+
+```bash
+node diagnose-injections.mjs                       # defaults to login page
+node diagnose-injections.mjs https://...
+```
+
+Output identifies the injecting file/function — useful for tracking
+down third-party CSP violations like the `@inertiajs/vue3` nprogress
+issue.
+
+### `extract-nprogress-css.mjs` — one-time utility
+
+Captured the verbatim nprogress CSS so we could ship it bundled (see
+`frontend/src/nprogress.css`). Kept for reference only — rerun if an
+Inertia.js upgrade changes the nprogress CSS and we need to recapture.
+
+## Failure interpretation
+
+| Symptom | Likely cause |
+| --- | --- |
+| `FAIL: style-src-elem still contains 'unsafe-inline'` | Middleware regression — someone reverted PR #56. |
+| `FAIL: nonce mismatch` | Context processor and middleware emitted different nonces — likely a middleware ordering or caching change. |
+| `FAIL: <style> injection NOT blocked` | The strict policy weakened — the XSS vector is open again. **Treat as P0**. |
+| `FAIL: element.style.* assignment violated CSP` | `style-src-attr 'unsafe-inline'` removed or restricted — every Vue `:style` binding in the app would break. |
+| `WARN: N console error(s)` listing `Refused to apply inline style` | Some new JS is injecting unnonced `<style>` blocks. Run `diagnose-injections.mjs` to find the source. |

--- a/scripts/csp-smoke/README.md
+++ b/scripts/csp-smoke/README.md
@@ -9,6 +9,8 @@ on habitreward.org. Created during the rollout of [issue #24][issue-24]
 
 ## Setup
 
+Requires Node.js >= 18 (native ESM, native fetch).
+
 ```bash
 cd scripts/csp-smoke
 npm install        # installs playwright 1.55

--- a/scripts/csp-smoke/diagnose-injections.mjs
+++ b/scripts/csp-smoke/diagnose-injections.mjs
@@ -6,6 +6,7 @@ import { chromium } from 'playwright';
 const URL = process.argv[2] || 'https://habitreward.org/auth/login/';
 
 const browser = await chromium.launch();
+try {
 const ctx = await browser.newContext();
 const page = await ctx.newPage();
 
@@ -72,4 +73,6 @@ for (const [i, s] of dom.entries()) {
     console.log(`    preview: ${s.preview.slice(0, 160)}`);
 }
 
-await browser.close();
+} finally {
+    await browser.close();
+}

--- a/scripts/csp-smoke/diagnose-injections.mjs
+++ b/scripts/csp-smoke/diagnose-injections.mjs
@@ -1,0 +1,75 @@
+// Diagnose: capture the textContent of every <style> tag in the DOM after
+// page load to identify what's injecting unnonced inline styles.
+
+import { chromium } from 'playwright';
+
+const URL = process.argv[2] || 'https://habitreward.org/auth/login/';
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+// Patch document.head.appendChild to log <style> insertions with their content.
+await page.addInitScript(() => {
+    window.__injectedStyles = [];
+    const origAppend = Element.prototype.appendChild;
+    Element.prototype.appendChild = function (node) {
+        if (node && node.nodeName === 'STYLE') {
+            window.__injectedStyles.push({
+                target: this.nodeName,
+                hasNonce: !!node.nonce || !!node.getAttribute('nonce'),
+                preview: (node.textContent || '').slice(0, 200),
+                length: (node.textContent || '').length,
+                stack: new Error().stack,
+            });
+        }
+        return origAppend.call(this, node);
+    };
+    const origInsert = Element.prototype.insertBefore;
+    Element.prototype.insertBefore = function (node, ref) {
+        if (node && node.nodeName === 'STYLE') {
+            window.__injectedStyles.push({
+                target: this.nodeName,
+                via: 'insertBefore',
+                hasNonce: !!node.nonce || !!node.getAttribute('nonce'),
+                preview: (node.textContent || '').slice(0, 200),
+                length: (node.textContent || '').length,
+                stack: new Error().stack,
+            });
+        }
+        return origInsert.call(this, node, ref);
+    };
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+
+// Allow Vue hydration to fully settle.
+await page.waitForTimeout(1500);
+
+const injected = await page.evaluate(() => window.__injectedStyles || []);
+
+console.log(`Found ${injected.length} dynamic <style> insertion attempt(s):\n`);
+for (const [i, info] of injected.entries()) {
+    console.log(`[${i + 1}] target=${info.target} hasNonce=${info.hasNonce} length=${info.length}`);
+    console.log(`    preview: ${info.preview.replace(/\s+/g, ' ').slice(0, 160)}`);
+    const stackLines = info.stack.split('\n').slice(1, 5);
+    console.log(`    stack:   ${stackLines[0]?.trim()}`);
+    console.log(`             ${stackLines[1]?.trim()}`);
+    console.log('');
+}
+
+// Also list <style> tags currently in DOM (in case some were created via innerHTML).
+const dom = await page.evaluate(() => {
+    return Array.from(document.querySelectorAll('style')).map((s) => ({
+        nonce: s.nonce || s.getAttribute('nonce') || null,
+        preview: (s.textContent || '').slice(0, 200).replace(/\s+/g, ' '),
+        length: (s.textContent || '').length,
+    }));
+});
+console.log(`\nDOM has ${dom.length} <style> tag(s) at the end:`);
+for (const [i, s] of dom.entries()) {
+    console.log(`[${i + 1}] nonce=${s.nonce} length=${s.length}`);
+    console.log(`    preview: ${s.preview.slice(0, 160)}`);
+}
+
+await browser.close();

--- a/scripts/csp-smoke/diagnose-injections.mjs
+++ b/scripts/csp-smoke/diagnose-injections.mjs
@@ -53,9 +53,10 @@ console.log(`Found ${injected.length} dynamic <style> insertion attempt(s):\n`);
 for (const [i, info] of injected.entries()) {
     console.log(`[${i + 1}] target=${info.target} hasNonce=${info.hasNonce} length=${info.length}`);
     console.log(`    preview: ${info.preview.replace(/\s+/g, ' ').slice(0, 160)}`);
-    const stackLines = info.stack.split('\n').slice(1, 5);
-    console.log(`    stack:   ${stackLines[0]?.trim()}`);
-    console.log(`             ${stackLines[1]?.trim()}`);
+    const stackLines = info.stack.split('\n').slice(1, 10);
+    for (const line of stackLines) {
+        console.log(`    stack:   ${line.trim()}`);
+    }
     console.log('');
 }
 

--- a/scripts/csp-smoke/extract-nprogress-css.mjs
+++ b/scripts/csp-smoke/extract-nprogress-css.mjs
@@ -1,0 +1,40 @@
+// One-shot: capture the full CSS content nprogress would inject so we
+// can ship it bundled instead.
+
+import { chromium } from 'playwright';
+import { writeFile } from 'node:fs/promises';
+
+const URL = process.argv[2] || 'https://habitreward.org/auth/login/';
+const OUT = process.argv[3] || '/tmp/nprogress-injected.css';
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({
+    bypassCSP: true,  // let nprogress inject so we can read it
+});
+const page = await ctx.newPage();
+
+await page.addInitScript(() => {
+    window.__capturedCSS = null;
+    const origAppend = Element.prototype.appendChild;
+    Element.prototype.appendChild = function (node) {
+        if (node && node.nodeName === 'STYLE' && node.textContent?.includes('#nprogress')) {
+            window.__capturedCSS = node.textContent;
+        }
+        return origAppend.call(this, node);
+    };
+});
+
+await page.goto(URL, { waitUntil: 'networkidle' });
+await page.waitForTimeout(1000);
+
+const css = await page.evaluate(() => window.__capturedCSS);
+if (!css) {
+    console.error('No nprogress CSS captured');
+    process.exit(1);
+}
+
+await writeFile(OUT, css);
+console.log(`Captured ${css.length} chars → ${OUT}`);
+console.log(`\nFirst 300 chars:\n${css.slice(0, 300)}`);
+
+await browser.close();

--- a/scripts/csp-smoke/extract-nprogress-css.mjs
+++ b/scripts/csp-smoke/extract-nprogress-css.mjs
@@ -12,6 +12,7 @@ const URL = process.argv[2] || 'https://habitreward.org/auth/login/';
 const OUT = process.argv[3] || '/tmp/nprogress-injected.css';
 
 const browser = await chromium.launch();
+try {
 const ctx = await browser.newContext({
     bypassCSP: true,  // let nprogress inject so we can read it
 });
@@ -41,4 +42,6 @@ await writeFile(OUT, css);
 console.log(`Captured ${css.length} chars → ${OUT}`);
 console.log(`\nFirst 300 chars:\n${css.slice(0, 300)}`);
 
-await browser.close();
+} finally {
+    await browser.close();
+}

--- a/scripts/csp-smoke/extract-nprogress-css.mjs
+++ b/scripts/csp-smoke/extract-nprogress-css.mjs
@@ -1,5 +1,9 @@
-// One-shot: capture the full CSS content nprogress would inject so we
-// can ship it bundled instead.
+// One-time utility — kept for reference, NOT part of normal CI/CD flow.
+//
+// Used once to capture the full CSS content nprogress would inject at
+// runtime, so we could ship it bundled instead (see
+// frontend/src/nprogress.css).  Re-run only if a future Inertia.js
+// upgrade changes the nprogress CSS and we need to recapture it.
 
 import { chromium } from 'playwright';
 import { writeFile } from 'node:fs/promises';

--- a/scripts/csp-smoke/extract-nprogress-css.mjs
+++ b/scripts/csp-smoke/extract-nprogress-css.mjs
@@ -35,13 +35,15 @@ await page.waitForTimeout(1000);
 const css = await page.evaluate(() => window.__capturedCSS);
 if (!css) {
     console.error('No nprogress CSS captured');
-    process.exit(1);
+    process.exitCode = 1;
+} else {
+    await writeFile(OUT, css);
+    console.log(`Captured ${css.length} chars → ${OUT}`);
+    console.log(`\nFirst 300 chars:\n${css.slice(0, 300)}`);
 }
-
-await writeFile(OUT, css);
-console.log(`Captured ${css.length} chars → ${OUT}`);
-console.log(`\nFirst 300 chars:\n${css.slice(0, 300)}`);
 
 } finally {
     await browser.close();
 }
+process.exit(process.exitCode ?? 0);
+

--- a/scripts/csp-smoke/package.json
+++ b/scripts/csp-smoke/package.json
@@ -1,14 +1,12 @@
 {
   "name": "csp-smoke",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "private": true,
+  "description": "Playwright-based smoke tests verifying Content-Security-Policy compliance on habitreward.org (issue #24).",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "smoke": "node run.mjs",
+    "diagnose": "node diagnose-injections.mjs"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "type": "module",
   "dependencies": {
     "playwright": "1.55"

--- a/scripts/csp-smoke/package.json
+++ b/scripts/csp-smoke/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "csp-smoke",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "playwright": "1.55"
+  }
+}

--- a/scripts/csp-smoke/package.json
+++ b/scripts/csp-smoke/package.json
@@ -9,6 +9,6 @@
   },
   "type": "module",
   "dependencies": {
-    "playwright": "1.55"
+    "playwright": "^1.55.0"
   }
 }

--- a/scripts/csp-smoke/run.mjs
+++ b/scripts/csp-smoke/run.mjs
@@ -89,7 +89,11 @@ if (!cspHeader) {
 
     // --- Check 2: meta nonce == header nonce ---
     const headerNonceTok = directives['style-src-elem']?.find((t) => t.startsWith("'nonce-"));
-    const headerNonce = headerNonceTok ? headerNonceTok.slice("'nonce-".length, -1) : null;
+    // Token must be quoted on BOTH sides — fail to null if the format
+    // ever changes rather than silently slice off something legitimate.
+    const headerNonce = headerNonceTok?.startsWith("'nonce-") && headerNonceTok.endsWith("'")
+        ? headerNonceTok.slice("'nonce-".length, -1)
+        : null;
     const metaNonce = await page.evaluate(() => {
         const m = document.querySelector('meta[name="csp-nonce"]');
         return m ? m.getAttribute('content') : null;

--- a/scripts/csp-smoke/run.mjs
+++ b/scripts/csp-smoke/run.mjs
@@ -14,6 +14,13 @@ import { chromium } from 'playwright';
 
 const URL = process.argv[2] || 'https://habitreward.org/auth/login/';
 
+// Negative probe: poll for the synchronously-fired CSP violation, cap so
+// a misconfigured (no-violation) policy doesn't hang the test.
+const VIOLATION_POLL_TIMEOUT_MS = 2000;
+// Positive probe: absence-of-event must be a fixed wait — long enough for
+// a violation to have fired if it was going to.
+const STYLE_ATTR_ABSENCE_WAIT_MS = 500;
+
 function fail(msg) {
     console.error(`FAIL: ${msg}`);
     process.exitCode = 1;
@@ -90,7 +97,7 @@ if (!cspHeader) {
 }
 
 // --- Check 3: NEGATIVE — JS-injected <style> without nonce must violate ---
-const violations = await page.evaluate(() => {
+const violations = await page.evaluate((pollLimitMs) => {
     return new Promise((resolve) => {
         const events = [];
         const handler = (e) => events.push({
@@ -109,10 +116,10 @@ const violations = await page.evaluate(() => {
         } catch (e) {}
 
         // Poll for the violation event; short-circuit as soon as it lands.
-        // Hard cap at 2 s to keep the test bounded on a slow browser.
+        // Hard cap (pollLimitMs) keeps the test bounded on a slow browser.
         const start = Date.now();
         const tick = () => {
-            if (events.length > 0 || Date.now() - start > 2000) {
+            if (events.length > 0 || Date.now() - start > pollLimitMs) {
                 document.removeEventListener('securitypolicyviolation', handler);
                 resolve(events);
             } else {
@@ -121,7 +128,7 @@ const violations = await page.evaluate(() => {
         };
         tick();
     });
-});
+}, VIOLATION_POLL_TIMEOUT_MS);
 
 const styleElemViolation = violations.find(
     (v) => v.effectiveDirective?.startsWith('style-src-elem') || v.violatedDirective?.startsWith('style-src-elem'),
@@ -132,7 +139,7 @@ else
     fail(`<style> injection NOT blocked — violations seen: ${JSON.stringify(violations)}`);
 
 // --- Check 4: POSITIVE — element.style.X assignment must NOT violate ---
-const attrViolations = await page.evaluate(() => {
+const attrViolations = await page.evaluate((absenceWaitMs) => {
     return new Promise((resolve) => {
         const events = [];
         const handler = (e) => events.push({
@@ -147,15 +154,16 @@ const attrViolations = await page.evaluate(() => {
         document.body.appendChild(d);
 
         // Positive probe: absence of an event has no natural completion
-        // signal, so we must wait a deterministic window.  500 ms is enough
-        // for a violation to have fired if it was going to.
+        // signal, so we must wait a deterministic window
+        // (STYLE_ATTR_ABSENCE_WAIT_MS) for a violation to have fired if it
+        // was going to.
         setTimeout(() => {
             document.removeEventListener('securitypolicyviolation', handler);
             d.remove();
             resolve(events);
-        }, 500);
+        }, absenceWaitMs);
     });
-});
+}, STYLE_ATTR_ABSENCE_WAIT_MS);
 
 const attrViolation = attrViolations.find(
     (v) => v.effectiveDirective?.startsWith('style-src-attr') || v.violatedDirective?.startsWith('style-src-attr'),

--- a/scripts/csp-smoke/run.mjs
+++ b/scripts/csp-smoke/run.mjs
@@ -12,7 +12,7 @@
 
 import { chromium } from 'playwright';
 
-const URL = process.argv[2] || 'https://habitreward.org/auth/login/';
+const TARGET = process.argv[2] || 'https://habitreward.org/auth/login/';
 
 // Negative probe: poll for the synchronously-fired CSP violation, cap so
 // a misconfigured (no-violation) policy doesn't hang the test.
@@ -41,15 +41,20 @@ page.on('console', (msg) => {
 });
 page.on('pageerror', (err) => consoleErrors.push(`pageerror: ${err.message}`));
 
-// Capture the CSP response header on document navigation.
+// Capture the CSP response header on document navigation.  Match on
+// parsed (origin, pathname) so query strings / fragments / trailing
+// slashes don't cause a miss.
+const targetURL = new URL(TARGET);
+const targetPath = targetURL.pathname.replace(/\/$/, '');
 let cspHeader = null;
 page.on('response', (resp) => {
-    if (resp.url() === URL || resp.url().replace(/\/$/, '') === URL.replace(/\/$/, '')) {
+    const u = new URL(resp.url());
+    if (u.origin === targetURL.origin && u.pathname.replace(/\/$/, '') === targetPath) {
         cspHeader = resp.headers()['content-security-policy'];
     }
 });
 
-const resp = await page.goto(URL, { waitUntil: 'networkidle' });
+const resp = await page.goto(TARGET, { waitUntil: 'networkidle' });
 if (!resp || resp.status() !== 200) {
     fail(`page load status=${resp?.status()}`);
     await browser.close();

--- a/scripts/csp-smoke/run.mjs
+++ b/scripts/csp-smoke/run.mjs
@@ -24,6 +24,7 @@ function pass(msg) {
 }
 
 const browser = await chromium.launch();
+try {
 const ctx = await browser.newContext();
 const page = await ctx.newPage();
 
@@ -172,5 +173,7 @@ if (consoleErrors.length > 0) {
     pass('no console errors during page load');
 }
 
-await browser.close();
+} finally {
+    await browser.close();
+}
 process.exit(process.exitCode ?? 0);

--- a/scripts/csp-smoke/run.mjs
+++ b/scripts/csp-smoke/run.mjs
@@ -1,0 +1,170 @@
+// Headless CSP smoke test against habitreward.org (issue #24 verification).
+//
+// Verifies:
+//   1. /auth/login/ page loads with no CSP / console errors.
+//   2. Meta-tag nonce == nonce in style-src-elem header.
+//   3. NEGATIVE: injecting an inline <style> block via JS without a valid
+//      nonce triggers a securitypolicyviolation (style-src-elem strict).
+//   4. POSITIVE: setting an element.style.color via JS does NOT violate
+//      (style-src-attr 'unsafe-inline' allows it).
+//
+// Run: node scripts/csp-smoke/run.mjs [URL]
+
+import { chromium } from 'playwright';
+
+const URL = process.argv[2] || 'https://habitreward.org/auth/login/';
+
+function fail(msg) {
+    console.error(`FAIL: ${msg}`);
+    process.exitCode = 1;
+}
+
+function pass(msg) {
+    console.log(`PASS: ${msg}`);
+}
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const consoleErrors = [];
+page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+});
+page.on('pageerror', (err) => consoleErrors.push(`pageerror: ${err.message}`));
+
+// Capture the CSP response header on document navigation.
+let cspHeader = null;
+page.on('response', (resp) => {
+    if (resp.url() === URL || resp.url().replace(/\/$/, '') === URL.replace(/\/$/, '')) {
+        cspHeader = resp.headers()['content-security-policy'];
+    }
+});
+
+const resp = await page.goto(URL, { waitUntil: 'networkidle' });
+if (!resp || resp.status() !== 200) {
+    fail(`page load status=${resp?.status()}`);
+    await browser.close();
+    process.exit(1);
+}
+pass(`page loaded (${resp.status()})`);
+
+// --- Check 1: CSP header parses, has split directives ---
+if (!cspHeader) {
+    fail('no Content-Security-Policy response header');
+} else {
+    const parsed = Object.fromEntries(
+        cspHeader.split(';').map((d) => d.trim().split(/\s+/, 1).concat([d.trim().split(/\s+/).slice(1)])).filter(([n]) => n).map(([n, t]) => [n, t]),
+    );
+    // Rebuild parsed properly:
+    const directives = {};
+    for (const part of cspHeader.split(';')) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+        const [name, ...tokens] = trimmed.split(/\s+/);
+        directives[name] = tokens;
+    }
+
+    if (!directives['style-src-elem']) fail('missing style-src-elem');
+    else pass(`style-src-elem present (${directives['style-src-elem'].join(' ')})`);
+
+    if (directives['style-src-elem']?.includes("'unsafe-inline'"))
+        fail("style-src-elem still contains 'unsafe-inline'");
+    else pass("style-src-elem does NOT contain 'unsafe-inline' (strict)");
+
+    if (!directives['style-src-attr']) fail('missing style-src-attr');
+    else pass(`style-src-attr present (${directives['style-src-attr'].join(' ')})`);
+
+    if (!directives['style-src']) fail('missing legacy style-src fallback');
+    else pass('legacy style-src fallback present');
+
+    // --- Check 2: meta nonce == header nonce ---
+    const headerNonceTok = directives['style-src-elem']?.find((t) => t.startsWith("'nonce-"));
+    const headerNonce = headerNonceTok ? headerNonceTok.slice("'nonce-".length, -1) : null;
+    const metaNonce = await page.evaluate(() => {
+        const m = document.querySelector('meta[name="csp-nonce"]');
+        return m ? m.getAttribute('content') : null;
+    });
+
+    if (!headerNonce) fail('no nonce token in style-src-elem');
+    else if (!metaNonce) fail('no <meta name="csp-nonce"> in document');
+    else if (headerNonce === metaNonce) pass(`meta nonce == header nonce (${metaNonce.slice(0, 8)}…)`);
+    else fail(`nonce mismatch: header=${headerNonce} meta=${metaNonce}`);
+}
+
+// --- Check 3: NEGATIVE — JS-injected <style> without nonce must violate ---
+const violations = await page.evaluate(() => {
+    return new Promise((resolve) => {
+        const events = [];
+        const handler = (e) => events.push({
+            blockedURI: e.blockedURI,
+            violatedDirective: e.violatedDirective,
+            effectiveDirective: e.effectiveDirective,
+            sample: e.sample,
+        });
+        document.addEventListener('securitypolicyviolation', handler);
+
+        // Negative probe: inline <style> block (no nonce, no 'unsafe-inline' on -elem)
+        try {
+            const s = document.createElement('style');
+            s.textContent = 'body { outline: 1px solid red; }';
+            document.head.appendChild(s);
+        } catch (e) {}
+
+        // Wait a tick for the event to fire.
+        setTimeout(() => {
+            document.removeEventListener('securitypolicyviolation', handler);
+            resolve(events);
+        }, 200);
+    });
+});
+
+const styleElemViolation = violations.find(
+    (v) => v.effectiveDirective?.startsWith('style-src-elem') || v.violatedDirective?.startsWith('style-src-elem'),
+);
+if (styleElemViolation)
+    pass(`<style> injection blocked by ${styleElemViolation.effectiveDirective || styleElemViolation.violatedDirective}`);
+else
+    fail(`<style> injection NOT blocked — violations seen: ${JSON.stringify(violations)}`);
+
+// --- Check 4: POSITIVE — element.style.X assignment must NOT violate ---
+const attrViolations = await page.evaluate(() => {
+    return new Promise((resolve) => {
+        const events = [];
+        const handler = (e) => events.push({
+            effectiveDirective: e.effectiveDirective,
+            violatedDirective: e.violatedDirective,
+        });
+        document.addEventListener('securitypolicyviolation', handler);
+
+        const d = document.createElement('div');
+        d.style.color = 'red';
+        d.style.transform = 'translateX(10px)';
+        document.body.appendChild(d);
+
+        setTimeout(() => {
+            document.removeEventListener('securitypolicyviolation', handler);
+            d.remove();
+            resolve(events);
+        }, 200);
+    });
+});
+
+const attrViolation = attrViolations.find(
+    (v) => v.effectiveDirective?.startsWith('style-src-attr') || v.violatedDirective?.startsWith('style-src-attr'),
+);
+if (attrViolation)
+    fail(`element.style assignment violated CSP (Vue :style would break!) — ${JSON.stringify(attrViolation)}`);
+else
+    pass("element.style.* assignment NOT blocked (Vue :style bindings safe)");
+
+// --- Check 5: surface any unexpected console errors ---
+if (consoleErrors.length > 0) {
+    console.warn(`WARN: ${consoleErrors.length} console error(s) during page load:`);
+    for (const e of consoleErrors) console.warn(`  - ${e}`);
+} else {
+    pass('no console errors during page load');
+}
+
+await browser.close();
+process.exit(process.exitCode ?? 0);

--- a/scripts/csp-smoke/run.mjs
+++ b/scripts/csp-smoke/run.mjs
@@ -53,10 +53,6 @@ pass(`page loaded (${resp.status()})`);
 if (!cspHeader) {
     fail('no Content-Security-Policy response header');
 } else {
-    const parsed = Object.fromEntries(
-        cspHeader.split(';').map((d) => d.trim().split(/\s+/, 1).concat([d.trim().split(/\s+/).slice(1)])).filter(([n]) => n).map(([n, t]) => [n, t]),
-    );
-    // Rebuild parsed properly:
     const directives = {};
     for (const part of cspHeader.split(';')) {
         const trimmed = part.trim();
@@ -111,11 +107,18 @@ const violations = await page.evaluate(() => {
             document.head.appendChild(s);
         } catch (e) {}
 
-        // Wait a tick for the event to fire.
-        setTimeout(() => {
-            document.removeEventListener('securitypolicyviolation', handler);
-            resolve(events);
-        }, 200);
+        // Poll for the violation event; short-circuit as soon as it lands.
+        // Hard cap at 2 s to keep the test bounded on a slow browser.
+        const start = Date.now();
+        const tick = () => {
+            if (events.length > 0 || Date.now() - start > 2000) {
+                document.removeEventListener('securitypolicyviolation', handler);
+                resolve(events);
+            } else {
+                setTimeout(tick, 25);
+            }
+        };
+        tick();
     });
 });
 
@@ -142,11 +145,14 @@ const attrViolations = await page.evaluate(() => {
         d.style.transform = 'translateX(10px)';
         document.body.appendChild(d);
 
+        // Positive probe: absence of an event has no natural completion
+        // signal, so we must wait a deterministic window.  500 ms is enough
+        // for a violation to have fired if it was going to.
         setTimeout(() => {
             document.removeEventListener('securitypolicyviolation', handler);
             d.remove();
             resolve(events);
-        }, 200);
+        }, 500);
     });
 });
 


### PR DESCRIPTION
## Summary
- Inertia.js's bundled nprogress loading bar injects ~1.2 KB of inline CSS at runtime via `document.head.appendChild(<style>)` with no CSP nonce. After #56 split `style-src` into strict `style-src-elem` (no `'unsafe-inline'`) and `style-src-attr`, that injection is blocked on modern browsers — the progress bar fails to render during Inertia client-side navigations.
- Fix: pass `progress: { includeCSS: false }` to `createInertiaApp()` and ship the same CSS bundled via `app.css` → loads as a hashed `<link rel="stylesheet">` covered by `style-src-elem 'self'`. CSP stays strict; bar works again.
- Adds `scripts/csp-smoke/` — Playwright smoke test (the one that surfaced this regression) that verifies the split directives are present, meta nonce matches header nonce, `<style>` injection is blocked, and `element.style.*` is NOT blocked. Reusable for future CSP work.

Discovered post-deploy of #56 via:
```
$ node scripts/csp-smoke/run.mjs
PASS: page loaded (200)
PASS: style-src-elem present (...)
...
WARN: 2 console error(s) during page load:
  - Refused to apply inline style because it violates ... "style-src-elem ..."
```
Stack trace from a patched `appendChild` pointed at `@inertiajs/vue3`'s nprogress integration.

## Test plan
- [x] `cd frontend && npm run build` succeeds; bundled `dist/main-*.css` contains 7 `#nprogress` rule blocks
- [x] `cd frontend && npx vitest run` — 93 passed, 3 failed (Layout.spec.js logout tests — **pre-existing on main**, unrelated)
- [x] Confirmed `@inertiajs/core` supports the `includeCSS` flag (`node_modules/@inertiajs/core/dist/index.js`)
- [ ] After deploy: re-run `node scripts/csp-smoke/run.mjs https://habitreward.org/auth/login/` — expect zero console CSP errors
- [ ] After deploy: navigate Today → Rewards via the in-app nav — expect blue loading bar at top during transition (visual)

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)