### PR TITLE
feat(0046): habit completion sink-bounce animation with sequenced reward popup

### DIFF
--- a/docs/features/0046_MANUAL_TEST_PLAN.md
+++ b/docs/features/0046_MANUAL_TEST_PLAN.md
@@ -1,0 +1,66 @@
+# Feature 0046 — Manual Test Plan
+
+These scenarios verify the sink-bounce animation, sequenced reward popup, and the schema migration's per-theme popup variants in a real browser. Automated tests cover the helper/migration plumbing; this checklist exists because animation timing, layout reflow, and reduced-motion behavior cannot be observed reliably in jsdom.
+
+**Prereqs**
+- Dev server: `uvicorn asgi:app --reload --port 8000` + `cd frontend && npm run dev`
+- Logged-in test user with at least 3 habits — one without any reward, one with a near-due reward (1 piece left), and one positioned at the bottom of the list
+
+## Scenarios
+
+### 1. Completion without a reward (happy path)
+
+1. From the Dashboard, mark a habit done that has no reward configured (or whose reward is not yet ready to fire).
+2. **Expect**: card animates downward with an overshoot-and-settle bounce into the bottom slot (~600 ms). No reward popup. Undo toast appears immediately after the animation completes.
+
+### 2. Completion that earns a reward
+
+1. Mark a habit done whose reward fires on this completion.
+2. **Expect**: card sink-bounces into bottom slot. Particles burst from the card's center mid-animation. After sink settles, the reward popup opens. Undo toast follows.
+3. Dismiss the popup → no layout shift; undo toast remains.
+
+### 3. Completing the bottommost habit
+
+1. Mark the last (bottom-positioned) habit done.
+2. **Expect**: deltaY is near 0, so the card performs an in-place mini-bounce. No flicker / horizontal jump. Sequencing identical to scenarios 1/2 depending on reward.
+
+### 4. Swipe-mode completion (verifies ref-placement fix)
+
+1. Switch to a theme whose `interactions.habitComplete` is `'swipe-reveal'`. (Currently no theme uses swipe by default; toggle via DB or theme editor if needed.)
+2. Mark a habit done by swiping.
+3. **Expect**: same sink-bounce as button mode. Previously the ref pointed at the `<HabitDoneSwipe>` component proxy, so `cardEl.getBoundingClientRect()` / `cardEl.animate()` would silently no-op; with the fix the animation must visibly run.
+
+### 5. `prefers-reduced-motion`
+
+1. Enable reduced motion at the OS level (macOS → System Settings → Accessibility → Display → Reduce motion) or via DevTools (Rendering tab → Emulate CSS media feature `prefers-reduced-motion: reduce`).
+2. Mark a habit done — both no-reward and reward variants.
+3. **Expect**: card does **not** animate. If a reward was earned, the popup appears immediately (no animation wait). Undo toast follows. No console errors.
+
+### 6. Grid-2 layout
+
+1. Switch to a theme with `pageLayout.habitList: 'grid-2'` (currently **Nature Forest** uses grid for `rewardList`, none use grid-2 for the habit list by default — verify via the theme picker or use DevTools to override `listLayoutClass`).
+2. Mark a habit done that needs to reorder across columns (i.e. its new bottom position is in a different column than its old position).
+3. **Expect**: the FLIP delta composes both X and Y. The card translates diagonally to its new grid slot with the same overshoot easing. No double-paint or jump.
+
+### 7. Per-theme reward popup variants
+
+For each of the 8 themes, complete a reward-earning habit and confirm the popup variant matches the migrated `reward.rewardPopupVariant`:
+
+| Theme              | Expected variant | Popup component  |
+|--------------------|------------------|------------------|
+| Clean Modern       | `default`        | `RewardDefault`  |
+| Gamified Arcade    | `particles`      | `RewardParticles`|
+| Cozy Warm          | `default`        | `RewardDefault`  |
+| iOS Native         | `default`        | `RewardDefault`  |
+| Dark Focus         | `quiet`          | `RewardQuiet`    |
+| Retro Terminal     | `quiet`          | `RewardQuiet`    |
+| Nature Forest      | `default`        | `RewardDefault`  |
+| Minimalist Zen     | `quiet`          | `RewardQuiet`    |
+
+**Expect**: the popup component matches the table; the `Theme.vue` personality-tag chip for `Particles` / `Quiet` themes still renders correctly in the theme picker.
+
+## Regressions to watch for
+
+- Reward popup opening **before** the sink animation finishes — would indicate the awaited `triggerCompletionCelebration` short-circuited (e.g. particle rejection escaping `Promise.all`).
+- Card not visibly moving in swipe mode — would indicate the `cardRef` regressed back onto the swipe component.
+- Console errors mentioning `cardEl.animate is not a function` — should be silently no-op'd; surfacing in console means the WAAPI fallback guard regressed.

--- a/docs/features/0046_PLAN.md
+++ b/docs/features/0046_PLAN.md
@@ -1,0 +1,233 @@
+# Feature 0046 — Habit Completion Sink-Bounce Animation
+
+## Context
+
+When a user marks a habit done on the Dashboard, the card currently snaps to the bottom of the list (server-side sort at `src/web/views/dashboard.py:77` places completed habits last) and — if a reward was earned — the `RewardCelebration` overlay opens *simultaneously* with the existing per-theme completion animation (`scale-up` / `burst-particles` / `fade-quiet`).
+
+This feature changes the flow so the user first **sees the card drop with a bounce into its new (bottom) slot**, and **only after that animation finishes** does the reward popup appear (if a reward was won). On reward wins, a particle burst plays mid-animation as additional flair. The card-drop animation is **global** — the same on all 8 themes.
+
+The existing `completionCelebration` theme field has *two* responsibilities in current code: (a) selecting the card animation variant in `useThemeAnimation.js`, and (b) selecting the reward popup variant component (`RewardParticles` / `RewardQuiet` / `RewardDefault`) in `RewardCelebration.vue:72-82`. Removing it wholesale would silently downgrade the popup look on 7 of 8 themes. We therefore **rename** the field to `rewardPopupVariant` and retain it for popup-component selection only; the card animation becomes globally driven by a single new helper.
+
+## Behavior
+
+1. User triggers completion via any of the existing interaction components (`HabitDoneButton`, `HabitDoneToggle`, `HabitDoneCheckbox`, `HabitDoneSwipe`).
+2. Dashboard captures the card's current bounding rect, then posts to `/habits/<id>/complete/`.
+3. On success, Inertia replaces the `habits` prop; the completed habit is repositioned to the bottom by the server.
+4. After Vue re-renders, the card's new rect is measured. The card animates from its old position (visual offset via `translate`) down to its new bottom slot with an overshoot-settle cubic-bezier (`cubic-bezier(0.34, 1.56, 0.64, 1)`) over ~600ms.
+5. If a reward was earned (and reduced-motion is not requested), a particle burst spawns from the card's center mid-animation.
+6. After the animation completes, the `RewardCelebration` popup opens — but **only if** `completionFlash.got_reward` is true. Popup component is chosen by the theme's `rewardPopupVariant`.
+7. The undo toast (existing) appears alongside.
+8. If the animation fails or WAAPI is unavailable, the sequencing still completes: popup and undo are not suppressed by animation errors.
+
+## Files Changed
+
+### `frontend/src/composables/useThemeAnimation.js`
+
+**Modify** `triggerCompletionCelebration` so it always runs the new sink-bounce animation and only emits particles when a reward was won — with reduced-motion gating at the entry point and resilient error handling.
+
+- Change signature from `triggerCompletionCelebration(cardEl)` to `triggerCompletionCelebration(cardEl, { oldRect, gotReward })`.
+- Remove the `switch (type)` branching on `animations.value.completionCelebration` — single global behavior.
+- Detect reduced-motion **inside `triggerCompletionCelebration`** (single check, gates both sink and particles): `if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;` — return resolved promise without animating.
+- Otherwise: kick off `animateSinkBounce(cardEl, oldRect)` and — if `gotReward` is true — `animateBurstParticles(cardEl)`, **both starting at t=0 in parallel**. Return `Promise.all([...])`. No `setTimeout` offset (particles naturally peak around the middle of their 600ms cycle, which lines up with the sink's overshoot frame; the offset added complexity without meaningful visual benefit).
+- Remove now-unused helpers `animateScaleUp` and `animateFadeQuiet`.
+- Keep `animateBurstParticles` (its `spawnParticles` import from `frontend/src/utils/particles.js` is unchanged).
+- **Export `animateSinkBounce`, `animateBurstParticles`, and `triggerCompletionCelebration` as standalone named exports.** The `useThemeAnimation()` composable's `triggerCompletionCelebration` method becomes a thin one-line delegate to the named export (no theme-context binding needed — behavior is now global). Single implementation, no divergence risk.
+
+**Add** `animateSinkBounce(cardEl, oldRect)`:
+
+- If `cardEl` is missing, return a resolved Promise (no-op).
+- If `typeof cardEl.animate !== 'function'` (WAAPI unavailable — jsdom, very old browsers), return a resolved Promise (no-op fallback — popup/undo still fire).
+- Read `newRect = cardEl.getBoundingClientRect()`.
+- Compute `deltaX = oldRect ? oldRect.left - newRect.left : 0` and `deltaY = oldRect ? oldRect.top - newRect.top : 0`.
+- Use the Web Animations API inside a `try/catch` (any sync throw → resolved Promise):
+  ```
+  const anim = cardEl.animate(
+    [
+      { transform: `translate(${deltaX}px, ${deltaY}px)` },
+      { transform: 'translate(0, 20px)', offset: 0.55 },
+      { transform: 'translate(0, -4px)', offset: 0.8 },
+      { transform: 'translate(0, 0)' },
+    ],
+    { duration: 600, easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)', fill: 'both' }
+  );
+  return anim.finished
+    .catch(() => undefined)        // swallow AbortError on cancel
+    .finally(() => anim.cancel?.());
+  ```
+- The `.catch()` ensures a cancellation does not propagate up and block the popup.
+
+**Update the file-header JSDoc** to drop `completionCelebration` and mention the new sink-bounce behavior.
+
+### `frontend/src/themes/index.js`
+
+Rename `completionCelebration` → `rewardPopupVariant` (semantically accurate — it now only drives the reward popup component selection).
+
+- Update doc comment (line 19): `{ cardEntrance, hoverMicro, streakFire }` (note: `rewardPopupVariant` moves to `reward`, not `animations`).
+- Move the field from `animations.completionCelebration` to `reward.rewardPopupVariant` (it belongs with `reward.displayMode` semantically).
+- Rename `VALID_COMPLETION_CELEBRATIONS` → `VALID_REWARD_POPUP_VARIANTS = new Set(['default', 'particles', 'quiet'])`.
+- Update `DEFAULTS.reward.rewardPopupVariant = 'default'`; remove `DEFAULTS.animations.completionCelebration`.
+- Migrate each of the 8 theme blocks. Actual theme names (verified in `frontend/src/themes/index.js`):
+
+  | Block line | Theme name | Current `completionCelebration` | New `rewardPopupVariant` |
+  |------------|------------|----------------------------------|--------------------------|
+  | 166 | Clean Modern | `scale-up` | `default` |
+  | 235 | Gamified Arcade | `burst-particles` | `particles` |
+  | 303 | Cozy Warm | `scale-up` | `default` |
+  | 372 | iOS Native | `scale-up` | `default` |
+  | 441 | Dark Focus | `fade-quiet` | `quiet` |
+  | 511 | Retro Terminal | `fade-quiet` | `quiet` |
+  | 580 | Nature Forest | `scale-up` | `default` |
+  | 649 | Minimalist Zen | `fade-quiet` | `quiet` |
+
+  Plus `DEFAULTS.animations.completionCelebration: 'none'` (line 70) → remove key from `animations`, add `DEFAULTS.reward.rewardPopupVariant = 'default'`.
+
+### `frontend/src/components/rewards/RewardCelebration.vue`
+
+Update `celebrationComponent` computed (line 72-82) to read `themeConfig.value.reward?.rewardPopupVariant` instead of `themeConfig.value.animations?.completionCelebration`:
+
+- `'particles'` → `RewardParticles`
+- `'quiet'` → `RewardQuiet`
+- default / `'default'` → `RewardDefault`
+
+### `frontend/src/pages/Theme.vue`
+
+Inside `getPersonalityTags(id)` (line 270+), the resolved theme is read as `const config = getTheme(id)` and `const anims = config.animations || {}` (line 290). After migration, `rewardPopupVariant` lives under `config.reward`, **not** `anims`. Update lines 291-292:
+
+- Replace `anims.completionCelebration === 'burst-particles'` with `config.reward?.rewardPopupVariant === 'particles'` → tag `'Particles'`.
+- Replace `anims.completionCelebration === 'fade-quiet'` with `config.reward?.rewardPopupVariant === 'quiet'` → tag `'Quiet'`.
+- (No tag emitted for `'default'`.)
+
+### `frontend/src/components/HabitCard.vue`
+
+**Swipe-mode ref placement bug fix** (uncovered by review). In current code, `ref="cardRef"` is on the `<HabitDoneSwipe>` *component* (line 3), so `defineExpose({ cardRef })` exposes a Vue component proxy, not a DOM element — `getBoundingClientRect()` / `cardEl.animate()` would fail in swipe mode.
+
+Fix: in swipe-mode template, move `ref="cardRef"` from the `<HabitDoneSwipe>` component to the inner `<div class="transition-all">` (current line 12). Standard mode is already correct (`ref="cardRef"` on the `<div>` at line 28). After the fix, `cardEl` is always a DOM element regardless of interaction mode.
+
+### `frontend/src/pages/Dashboard.vue`
+
+Modify `completeHabit(habitId)` ([Dashboard.vue:121-159](frontend/src/pages/Dashboard.vue#L121-L159)) to sequence: rect-capture → API call → re-render wait → sink animation → (conditional) popup. Guarantee popup/undo fire even if animation throws.
+
+- Import `nextTick` from `'vue'`.
+- Before calling `router.post`, capture `oldRect = cardEl?.getBoundingClientRect?.() ?? null`. `cardEl` is resolved from `cardRefs[habitId]?.cardRef` as it is today.
+- The `router.post` `onSuccess` callback becomes `async` and wraps the animation `await` in `try/catch` (popup/undo run unconditionally outside the block):
+  1. `await nextTick()` — ensures Inertia's new `habits` prop has been applied and `HabitCard` for this habit id sits in its new (bottom) DOM position. (Same `:key="habit.id"` keeps the same DOM element, so `cardEl` is still valid.)
+  2. Determine `gotReward = !!(flash?.got_reward && flash?.reward_name)`.
+  3. `try { await triggerCompletionCelebration(cardEl, { oldRect, gotReward }); } catch { /* swallow — never block popup/undo */ }`
+  4. (Outside try, runs unconditionally): if `gotReward`, populate `celebrationData` (`rewardName`, `piecesEarned`, `piecesRequired`, `cardRect: cardEl?.getBoundingClientRect?.() ?? null`) and set `celebrationVisible.value = true`.
+  5. `showUndo(habitId, flash?.text || "Habit completed")` (existing).
+- The realtime pause window (currently 4000ms in `realtimePauseTimer`) remains adequate (600ms sink + popup display).
+- `onFinish` continues to clear `loadingId`.
+
+### `frontend/tests/themes.spec.js`
+
+Update existing assertions and import:
+
+- Top-of-file import: change `import { themes, VALID_COMPLETION_CELEBRATIONS }` → `import { themes, VALID_REWARD_POPUP_VARIANTS }`.
+- Line 62 (existing): change `expect(config.animations).toHaveProperty("completionCelebration")` → `expect(config.reward).toHaveProperty("rewardPopupVariant")`.
+- Line 81 (existing): change `VALID_COMPLETION_CELEBRATIONS.has(config.animations.completionCelebration)` → `VALID_REWARD_POPUP_VARIANTS.has(config.reward.rewardPopupVariant)`.
+- Add forward-compat guards against deprecated key reintroduction. The resolved-config check alone catches both DEFAULTS leakage and raw-theme reintroduction (because `deepMerge` does not strip unknown keys — see `index.js:86-103`), but checking raw blocks too gives a more pinpoint failure location:
+  - `expect('completionCelebration' in config.animations).toBe(false)` (resolved config — catches both classes of regression).
+  - Iterate `themes` array directly and assert `'completionCelebration' in (theme.animations ?? {}) === false` for each raw block (diagnostic clarity only).
+
+### `frontend/tests/themeAnimation.spec.js` (NEW)
+
+Unit tests for the newly-exported helpers. Use vitest's jsdom environment; stub `HTMLElement.prototype.animate` (jsdom does not implement WAAPI) and `window.matchMedia`. Tests import the helpers directly from `useThemeAnimation.js` (now exported).
+
+## Algorithm: Sink-Bounce Sequencing
+
+Step-by-step:
+
+1. **Pre-flight (sync)** — `oldRect = cardEl.getBoundingClientRect()`. Captures the visible position *before* Inertia replaces props.
+2. **Server round-trip (async)** — `router.post('/habits/<id>/complete/', …)`. Server marks habit done, computes flash data, and re-renders dashboard props with completed habits last.
+3. **DOM settle (async)** — `await nextTick()`. Vue applies new prop ordering; because `<HabitCard>` uses `:key="habit.id"`, the same DOM node is re-parented to its new slot. `cardEl` reference remains valid.
+4. **Reduced-motion gate (sync)** — if `prefers-reduced-motion: reduce`, skip directly to step 8.
+5. **Delta compute (sync)** — `newRect = cardEl.getBoundingClientRect()`; `deltaX = oldRect.left - newRect.left`; `deltaY = oldRect.top - newRect.top`. Typically `deltaY` is negative (the card now lives lower than it visually appears mid-animation start).
+6. **Frame 0 (browser paint)** — Card visually sits at `translate(deltaX, deltaY)` — its old position.
+7. **Frames 1..N (~600ms)** — Web Animations interpolates with `cubic-bezier(0.34, 1.56, 0.64, 1)`:
+   - 0%: at old position offset.
+   - 55%: overshoots ~20px past final resting Y, X already at 0.
+   - 80%: bounces back to ~−4px above resting Y.
+   - 100%: settles at `translate(0, 0)`.
+8. **Particle parallel (conditional)** — If `gotReward` AND not reduced-motion, `animateBurstParticles` is started **at t=0 in parallel** with the sink. Particles naturally peak around 300ms into their 600ms cycle, lining up with the sink's overshoot frame.
+9. **Resolution** — `await Promise.all([sinkPromise, particlePromise])`. Inline transform is cleared so Vue's static layout takes over. Animation rejections are swallowed (`.catch`) to prevent blocking the popup.
+10. **Popup (conditional)** — `celebrationVisible = true` only if `gotReward`. Popup component is selected by `rewardPopupVariant`. The popup's `cardRect` prop uses the now-settled new position.
+
+### Reduced-motion fallback
+
+Gated **once** at the entry of `triggerCompletionCelebration`:
+
+- Both `animateSinkBounce` and `animateBurstParticles` are skipped.
+- The function returns an immediately-resolved promise.
+- Dashboard awaits → popup (if reward) appears immediately on the next tick.
+
+### Resilience guarantees
+
+- **Missing `cardEl`** (component unmounted between post and onSuccess): `animateSinkBounce` no-ops; popup still fires if `gotReward`.
+- **Missing WAAPI** (older browser, jsdom): `typeof cardEl.animate !== 'function'` check → no-op; popup still fires.
+- **`animate()` throws synchronously**: wrapped in `try/catch` inside `animateSinkBounce` → resolved promise.
+- **Animation cancelled (`AbortError`)**: `.catch` swallows; promise resolves.
+- **Any other error**: outer `try/catch` in Dashboard's `onSuccess` ensures popup/undo run regardless.
+
+### Edge cases
+
+- **`oldRect` missing** (e.g., first render race): `deltaX = deltaY = 0`. Keyframe still produces an in-place mini-bounce.
+- **Card already at bottom**: `deltaY ≈ 0`. Same in-place mini-bounce — acceptable visual feedback.
+- **Grid layout (`grid-2`)**: horizontal reorder is handled by `deltaX`. Cubic-bezier easing applies to the composed translate.
+- **WebSocket realtime update mid-animation**: existing 4-second `realtimePauseTimer` (Dashboard.vue:127-130) covers the 600ms window; no additional pause needed.
+
+## Unit Test Scenarios
+
+### `frontend/tests/themeAnimation.spec.js` (new)
+
+Stub setup: replace `HTMLElement.prototype.animate` with a vitest spy returning `{ finished: Promise.resolve(), cancel: vi.fn() }` and stub `window.matchMedia` (default `matches: false`).
+
+1. **`animateSinkBounce` resolves after Web Animation finishes**
+   - Given a stubbed `cardEl` whose `getBoundingClientRect()` returns `{ top: 100, left: 0, ... }` and `oldRect = { top: 40, left: 0 }`.
+   - `animate` was called once with first keyframe `translate(0px, -60px)`, last keyframe `translate(0, 0)`, duration 600.
+   - Returned promise resolves.
+
+2. **`animateSinkBounce` no-ops with missing element**
+   - `animateSinkBounce(null, anyRect)` resolves immediately; `animate` is not called.
+
+3. **`animateSinkBounce` no-ops when WAAPI missing**
+   - Stub element without `.animate` method → resolves immediately; no throw.
+
+4. **`animateSinkBounce` swallows `animate()` throws**
+   - Stub `animate` to throw → promise still resolves (not rejects).
+
+5. **`animateSinkBounce` swallows `finished` rejection**
+   - Stub returns `{ finished: Promise.reject(new Error('Aborted')), cancel: vi.fn() }` → promise resolves.
+
+6. **`animateSinkBounce` handles missing oldRect**
+   - `animateSinkBounce(cardEl, null)` calls `animate` with first keyframe `translate(0px, 0px)`.
+
+7. **`triggerCompletionCelebration({ gotReward: false })`** — invokes only `animateSinkBounce`; `spawnParticles` mock is not called.
+
+8. **`triggerCompletionCelebration({ gotReward: true })`** — invokes both `animateSinkBounce` and `animateBurstParticles` in parallel (both called synchronously from the entry point, no `setTimeout`); returned promise resolves only after both have completed (assert via two resolved-stub spies whose order does not matter).
+
+9. **`triggerCompletionCelebration` with reduced-motion**
+   - Stub `matchMedia('(prefers-reduced-motion: reduce)')` to return `{ matches: true }`.
+   - Neither `animate` nor `spawnParticles` is called; promise resolves immediately.
+
+10. **Composed delta with horizontal offset** (grid layout): given `oldRect = { top: 0, left: 100 }`, `newRect = { top: 40, left: 50 }`, first keyframe is `translate(50px, -40px)`, last is `translate(0, 0)`.
+
+### `frontend/tests/themes.spec.js` (modify)
+
+11. **All themes have valid `rewardPopupVariant`** (replaces existing `completionCelebration` assertion).
+12. **No theme exposes deprecated `completionCelebration`** in `animations` — forward-compat guard.
+
+### Manual test scenarios (Dashboard.vue)
+
+Recorded in `docs/features/0046_MANUAL_TEST_PLAN.md` (created during implementation), covering:
+
+- Complete a habit that has NO reward → see card sink+bounce → no popup → undo toast appears.
+- Complete a habit that earns a reward → see card sink+bounce → particles → popup → undo toast.
+- Complete the bottommost habit → in-place mini-bounce → behavior otherwise identical.
+- Complete via **swipe** interaction (uses HabitDoneSwipe) → sink+bounce still plays (verifies the ref-placement fix).
+- Complete with prefers-reduced-motion enabled → no animation, no particles, popup (if any) appears immediately.
+- Complete in grid-2 layout theme → composed X+Y motion lands at new grid slot.
+- Each theme's reward popup variant renders correctly (verifies `rewardPopupVariant` migration): Gamified Arcade → `RewardParticles`; Dark Focus / Retro Terminal / Minimalist Zen → `RewardQuiet`; Clean Modern / Cozy Warm / iOS Native / Nature Forest → `RewardDefault`.
+
+## Out of scope
+
+- **Concurrent multi-habit completion animations.** Current `loadingId` is a single value (Dashboard.vue:110); two rapid completions on *different* habits would race the loading-id state. Not addressed in this feature — if surfaced as a problem, a follow-up can convert `loadingId` into a `Set<habitId>`. The animation itself does not assume single-flight (each call captures its own `oldRect` and runs an independent WAAPI animation).

--- a/docs/features/0046_REVIEW.md
+++ b/docs/features/0046_REVIEW.md
@@ -2,32 +2,27 @@
 
 ## Findings
 
-### P0 - Feature 0046 is not implemented
+### P2 - Optional particle failures can bypass the sink-bounce wait
 
-The source tree still contains the pre-0046 completion animation flow. `frontend/src/composables/useThemeAnimation.js:120` still reads `animations.value.completionCelebration` and dispatches to `animateScaleUp`, `animateBurstParticles`, or `animateFadeQuiet`; there is no exported `animateSinkBounce`, no `{ oldRect, gotReward }` argument, no reduced-motion gate, and no WAAPI fallback behavior. This means the global sink-bounce animation described by the plan never runs.
+`triggerCompletionCelebration()` starts the sink animation and reward particles together, then awaits them via `Promise.all()` (`frontend/src/composables/useThemeAnimation.js:146-148`). `animateSinkBounce()` swallows its own WAAPI cancellation/failure paths, but `animateBurstParticles()` does not catch failures from `getBoundingClientRect()`, the dynamic import, or `spawnParticles()` (`frontend/src/composables/useThemeAnimation.js:119-129`).
 
-The dashboard sequencing is also unchanged. `frontend/src/pages/Dashboard.vue:132` posts the completion request, then `onSuccess` immediately calls `triggerCompletionCelebration(cardEl)` at `frontend/src/pages/Dashboard.vue:141` and immediately opens the reward popup at `frontend/src/pages/Dashboard.vue:150`. It does not capture the pre-submit rect, does not `await nextTick()`, does not await animation completion before showing the popup, and does not wrap the animation in a resilience guard. This preserves the exact bug the feature is intended to fix: reward popup and card animation can happen simultaneously, and the card cannot animate from its old slot to its new bottom slot.
+`Dashboard.vue` catches the rejected `triggerCompletionCelebration()` call and immediately proceeds to show the reward popup and undo toast (`frontend/src/pages/Dashboard.vue:151-165`). If the particle path rejects while the sink animation is still running, the popup can open before the card finishes settling, which violates the main sequencing requirement for reward wins. The robust shape is to isolate the optional particle failure while still awaiting the sink promise, for example by catching the particle promise individually or using `Promise.allSettled()` after guaranteeing the sink promise is included.
 
-### P0 - Theme schema migration was not applied
+### P3 - The manual test plan referenced by the implementation plan is missing
 
-`completionCelebration` remains in the theme schema and theme data. The deprecated validation constant is still exported at `frontend/src/themes/index.js:33`, the default still sets `DEFAULTS.animations.completionCelebration` at `frontend/src/themes/index.js:70`, and individual themes still define `animations.completionCelebration` such as `clean_modern` at `frontend/src/themes/index.js:166`, `gamified_arcade` at `frontend/src/themes/index.js:235`, `dark_focus` at `frontend/src/themes/index.js:441`, and `minimalist_zen` at `frontend/src/themes/index.js:649`.
+`docs/features/0046_PLAN.md` says the manual scenarios are recorded in `docs/features/0046_MANUAL_TEST_PLAN.md`, but that file is not present. The automated coverage is good for the helper and theme migration paths, but the requested manual coverage for real dashboard interactions, swipe mode, reduced motion, grid layout, and per-theme popup variants is not documented in the repo.
 
-The planned `reward.rewardPopupVariant` field and `VALID_REWARD_POPUP_VARIANTS` export are absent. As a result, reward popup selection still depends on the old animation key, and the forward-compat guard requested by the plan cannot exist.
+## Implementation Check
 
-### P1 - Reward popup and theme picker still read the old field
+The main code paths match the plan:
 
-`RewardCelebration` still chooses its component from `themeConfig.value.animations?.completionCelebration` at `frontend/src/components/rewards/RewardCelebration.vue:73`, mapping `"burst-particles"` and `"fade-quiet"` directly. `Theme.vue` still derives personality tags from `anims.completionCelebration` at `frontend/src/pages/Theme.vue:291`. Both should read `config.reward?.rewardPopupVariant` after the migration.
+- `completionCelebration` was removed from theme config and replaced by `reward.rewardPopupVariant`.
+- `RewardCelebration.vue` and `Theme.vue` read the new reward variant field.
+- `HabitCard.vue` moved the swipe-mode exposed ref onto a DOM element.
+- `Dashboard.vue` captures the old rect, waits for `nextTick()`, awaits the completion animation, and only then opens the reward popup.
+- `useThemeAnimation.js` exports `animateSinkBounce`, `animateBurstParticles`, and `triggerCompletionCelebration`, with reduced-motion gating at the entry point.
 
-If only the theme data were migrated later, these two call sites would silently fall back to `RewardDefault` and stop showing the intended `Particles` / `Quiet` labels.
+## Validation
 
-### P1 - Swipe-mode DOM ref bug remains
-
-The plan calls out a swipe-mode ref placement bug, but `frontend/src/components/HabitCard.vue:5` still places `ref="cardRef"` on the `<HabitDoneSwipe>` component instead of the inner DOM `<div>` at `frontend/src/components/HabitCard.vue:11`. In swipe mode, `defineExpose({ cardRef })` can expose a component proxy rather than an element, so `getBoundingClientRect()` and WAAPI `.animate()` are not reliable.
-
-### P1 - Required animation tests are missing
-
-`frontend/tests/themeAnimation.spec.js` does not exist, and `frontend/tests/themes.spec.js:7` still imports `VALID_COMPLETION_CELEBRATIONS`. The existing schema tests still assert `config.animations.completionCelebration` at `frontend/tests/themes.spec.js:62` and validate it at `frontend/tests/themes.spec.js:81`. These tests currently reinforce the old contract instead of guarding the new one.
-
-## Notes
-
-I did not run the frontend test suite because the inspected implementation does not include the planned code paths yet; the review is blocked at source inspection.
+- `npm test -- tests/themeAnimation.spec.js tests/themes.spec.js` passed: 79 tests.
+- `npm run build` passed. Vite emitted a non-blocking warning that `particles.js` is dynamically imported by `useThemeAnimation.js` and also statically imported by `RewardParticles.vue`, so that dynamic import will not create a separate chunk.

--- a/docs/features/0046_REVIEW.md
+++ b/docs/features/0046_REVIEW.md
@@ -2,15 +2,15 @@
 
 ## Findings
 
-### P2 - Optional particle failures can bypass the sink-bounce wait
+### ✅ Resolved in 9e013b2 — P2 - Optional particle failures can bypass the sink-bounce wait
 
-`triggerCompletionCelebration()` starts the sink animation and reward particles together, then awaits them via `Promise.all()` (`frontend/src/composables/useThemeAnimation.js:146-148`). `animateSinkBounce()` swallows its own WAAPI cancellation/failure paths, but `animateBurstParticles()` does not catch failures from `getBoundingClientRect()`, the dynamic import, or `spawnParticles()` (`frontend/src/composables/useThemeAnimation.js:119-129`).
+> **Status: fixed.** `animateBurstParticles` now wraps its body in try/catch so a particle rejection (from `getBoundingClientRect()`, the dynamic import, or `spawnParticles()`) is swallowed locally and cannot escape `Promise.all` to abort the sink-wait. Regression test added in `frontend/tests/themeAnimation.spec.js` ("particle rejection does not abort the sink animation wait").
 
-`Dashboard.vue` catches the rejected `triggerCompletionCelebration()` call and immediately proceeds to show the reward popup and undo toast (`frontend/src/pages/Dashboard.vue:151-165`). If the particle path rejects while the sink animation is still running, the popup can open before the card finishes settling, which violates the main sequencing requirement for reward wins. The robust shape is to isolate the optional particle failure while still awaiting the sink promise, for example by catching the particle promise individually or using `Promise.allSettled()` after guaranteeing the sink promise is included.
+Original finding (kept for historical context): `triggerCompletionCelebration()` started the sink animation and reward particles together via `Promise.all()`. `animateSinkBounce()` swallowed its own WAAPI cancellation/failure paths, but `animateBurstParticles()` did not catch failures from `getBoundingClientRect()`, the dynamic import, or `spawnParticles()`. If the particle path rejected while the sink was still running, `Promise.all` rejected fast and Dashboard's outer `try/catch` proceeded to open the reward popup before the card settled.
 
-### P3 - The manual test plan referenced by the implementation plan is missing
+### ✅ Resolved in 9e013b2 — P3 - The manual test plan referenced by the implementation plan is missing
 
-`docs/features/0046_PLAN.md` says the manual scenarios are recorded in `docs/features/0046_MANUAL_TEST_PLAN.md`, but that file is not present. The automated coverage is good for the helper and theme migration paths, but the requested manual coverage for real dashboard interactions, swipe mode, reduced motion, grid layout, and per-theme popup variants is not documented in the repo.
+> **Status: fixed.** `docs/features/0046_MANUAL_TEST_PLAN.md` now exists with the 7 manual scenarios (no-reward / reward / bottom / swipe / reduced-motion / grid / per-theme variants).
 
 ## Implementation Check
 

--- a/docs/features/0046_REVIEW.md
+++ b/docs/features/0046_REVIEW.md
@@ -1,0 +1,33 @@
+# Feature 0046 Code Review
+
+## Findings
+
+### P0 - Feature 0046 is not implemented
+
+The source tree still contains the pre-0046 completion animation flow. `frontend/src/composables/useThemeAnimation.js:120` still reads `animations.value.completionCelebration` and dispatches to `animateScaleUp`, `animateBurstParticles`, or `animateFadeQuiet`; there is no exported `animateSinkBounce`, no `{ oldRect, gotReward }` argument, no reduced-motion gate, and no WAAPI fallback behavior. This means the global sink-bounce animation described by the plan never runs.
+
+The dashboard sequencing is also unchanged. `frontend/src/pages/Dashboard.vue:132` posts the completion request, then `onSuccess` immediately calls `triggerCompletionCelebration(cardEl)` at `frontend/src/pages/Dashboard.vue:141` and immediately opens the reward popup at `frontend/src/pages/Dashboard.vue:150`. It does not capture the pre-submit rect, does not `await nextTick()`, does not await animation completion before showing the popup, and does not wrap the animation in a resilience guard. This preserves the exact bug the feature is intended to fix: reward popup and card animation can happen simultaneously, and the card cannot animate from its old slot to its new bottom slot.
+
+### P0 - Theme schema migration was not applied
+
+`completionCelebration` remains in the theme schema and theme data. The deprecated validation constant is still exported at `frontend/src/themes/index.js:33`, the default still sets `DEFAULTS.animations.completionCelebration` at `frontend/src/themes/index.js:70`, and individual themes still define `animations.completionCelebration` such as `clean_modern` at `frontend/src/themes/index.js:166`, `gamified_arcade` at `frontend/src/themes/index.js:235`, `dark_focus` at `frontend/src/themes/index.js:441`, and `minimalist_zen` at `frontend/src/themes/index.js:649`.
+
+The planned `reward.rewardPopupVariant` field and `VALID_REWARD_POPUP_VARIANTS` export are absent. As a result, reward popup selection still depends on the old animation key, and the forward-compat guard requested by the plan cannot exist.
+
+### P1 - Reward popup and theme picker still read the old field
+
+`RewardCelebration` still chooses its component from `themeConfig.value.animations?.completionCelebration` at `frontend/src/components/rewards/RewardCelebration.vue:73`, mapping `"burst-particles"` and `"fade-quiet"` directly. `Theme.vue` still derives personality tags from `anims.completionCelebration` at `frontend/src/pages/Theme.vue:291`. Both should read `config.reward?.rewardPopupVariant` after the migration.
+
+If only the theme data were migrated later, these two call sites would silently fall back to `RewardDefault` and stop showing the intended `Particles` / `Quiet` labels.
+
+### P1 - Swipe-mode DOM ref bug remains
+
+The plan calls out a swipe-mode ref placement bug, but `frontend/src/components/HabitCard.vue:5` still places `ref="cardRef"` on the `<HabitDoneSwipe>` component instead of the inner DOM `<div>` at `frontend/src/components/HabitCard.vue:11`. In swipe mode, `defineExpose({ cardRef })` can expose a component proxy rather than an element, so `getBoundingClientRect()` and WAAPI `.animate()` are not reliable.
+
+### P1 - Required animation tests are missing
+
+`frontend/tests/themeAnimation.spec.js` does not exist, and `frontend/tests/themes.spec.js:7` still imports `VALID_COMPLETION_CELEBRATIONS`. The existing schema tests still assert `config.animations.completionCelebration` at `frontend/tests/themes.spec.js:62` and validate it at `frontend/tests/themes.spec.js:81`. These tests currently reinforce the old contract instead of guarding the new one.
+
+## Notes
+
+I did not run the frontend test suite because the inspected implementation does not include the planned code paths yet; the review is blocked at source inspection.

--- a/frontend/src/components/HabitCard.vue
+++ b/frontend/src/components/HabitCard.vue
@@ -2,13 +2,13 @@
   <!-- Swipe mode: the swipe component wraps everything -->
   <HabitDoneSwipe
     v-if="isSwipeMode"
-    ref="cardRef"
     :habit="habit"
     :loading="loading"
     @complete="$emit('complete', $event)"
     @revert="$emit('revert', $event)"
   >
     <div
+      ref="cardRef"
       class="transition-all"
       :class="[
         densityPadding,

--- a/frontend/src/components/rewards/RewardCelebration.vue
+++ b/frontend/src/components/rewards/RewardCelebration.vue
@@ -70,11 +70,11 @@ const isToast = computed(() =>
 );
 
 const celebrationComponent = computed(() => {
-  const type = themeConfig.value.animations?.completionCelebration;
-  switch (type) {
-    case "burst-particles":
+  const variant = themeConfig.value.reward?.rewardPopupVariant;
+  switch (variant) {
+    case "particles":
       return RewardParticles;
-    case "fade-quiet":
+    case "quiet":
       return RewardQuiet;
     default:
       return RewardDefault;

--- a/frontend/src/composables/useThemeAnimation.js
+++ b/frontend/src/composables/useThemeAnimation.js
@@ -1,11 +1,11 @@
 /**
- * Theme animation composable (Phase 1 infrastructure).
+ * Theme animation composable.
  *
- * Provides helpers to apply theme-driven animations:
- * - Card entrance styles (inline style objects)
+ * Provides helpers for theme-driven animations:
+ * - Card entrance styles
  * - Streak fire CSS classes
  * - Hover micro-interaction CSS classes
- * - Completion celebration triggers
+ * - Global sink-bounce completion animation with conditional particle burst
  */
 
 import { computed } from "vue";
@@ -79,6 +79,76 @@ export function hoverMicroClass(type) {
 }
 
 /**
+ * FLIP-based sink-bounce animation. Translates the card from its old position
+ * to its new (post-rerender) resting slot with an overshoot-settle curve.
+ *
+ * @param {HTMLElement} cardEl
+ * @param {DOMRect|null} oldRect
+ * @returns {Promise<void>}
+ */
+export function animateSinkBounce(cardEl, oldRect) {
+  if (!cardEl) return Promise.resolve();
+  if (typeof cardEl.animate !== 'function') return Promise.resolve();
+  try {
+    const newRect = cardEl.getBoundingClientRect();
+    const deltaX = oldRect ? oldRect.left - newRect.left : 0;
+    const deltaY = oldRect ? oldRect.top - newRect.top : 0;
+    const anim = cardEl.animate(
+      [
+        { transform: `translate(${deltaX}px, ${deltaY}px)` },
+        { transform: 'translate(0, 20px)', offset: 0.55 },
+        { transform: 'translate(0, -4px)', offset: 0.8 },
+        { transform: 'translate(0, 0)' },
+      ],
+      { duration: 600, easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)', fill: 'both' }
+    );
+    return anim.finished
+      .catch(() => undefined)
+      .finally(() => anim.cancel?.());
+  } catch {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Spawn a burst of particles from the card's center.
+ *
+ * @param {HTMLElement} el
+ * @returns {Promise<void>}
+ */
+export async function animateBurstParticles(el) {
+  if (!el) return;
+  const rect = el.getBoundingClientRect();
+  const { spawnParticles } = await import('../utils/particles.js');
+  await spawnParticles({
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+    count: 12,
+    colors: ['#06b6d4', '#ec4899', '#fbbf24', '#10b981'],
+    duration: 600,
+  });
+}
+
+/**
+ * Global completion celebration: sink-bounce, plus parallel particle burst on reward.
+ * Reduced-motion gating is applied once at entry.
+ *
+ * @param {HTMLElement} cardEl
+ * @param {{ oldRect?: DOMRect|null, gotReward?: boolean }} opts
+ * @returns {Promise<void>}
+ */
+export function triggerCompletionCelebration(cardEl, opts = {}) {
+  const { oldRect = null, gotReward = false } = opts;
+  if (typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+    return Promise.resolve();
+  }
+  const tasks = [animateSinkBounce(cardEl, oldRect)];
+  if (gotReward) tasks.push(animateBurstParticles(cardEl));
+  return Promise.all(tasks).then(() => undefined);
+}
+
+/**
  * Composable providing reactive animation helpers tied to current theme.
  */
 export function useThemeAnimation() {
@@ -112,67 +182,7 @@ export function useThemeAnimation() {
     /** Reactive hover micro-interaction class. */
     hoverClass,
 
-    /**
-     * Trigger a completion celebration animation on an element.
-     * @param {HTMLElement} cardEl
-     * @returns {Promise<void>}
-     */
-    async triggerCompletionCelebration(cardEl) {
-      const type = animations.value.completionCelebration;
-      switch (type) {
-        case 'scale-up':
-          await animateScaleUp(cardEl);
-          break;
-        case 'burst-particles':
-          await animateBurstParticles(cardEl);
-          break;
-        case 'fade-quiet':
-          await animateFadeQuiet(cardEl);
-          break;
-        default:
-          break;
-      }
-    },
+    /** Delegates to the standalone named export — behavior is now global. */
+    triggerCompletionCelebration,
   };
-}
-
-// ── Internal animation handlers ─────────────────────────────────────
-
-async function animateScaleUp(el) {
-  if (!el) return;
-  el.style.transition = 'transform 0.2s ease-out';
-  el.style.transform = 'scale(1.03)';
-  await sleep(200);
-  el.style.transform = 'scale(1)';
-  await sleep(200);
-  el.style.transition = '';
-  el.style.transform = '';
-}
-
-async function animateBurstParticles(el) {
-  if (!el) return;
-  const rect = el.getBoundingClientRect();
-  const { spawnParticles } = await import('../utils/particles.js');
-  await spawnParticles({
-    x: rect.left + rect.width / 2,
-    y: rect.top + rect.height / 2,
-    count: 12,
-    colors: ['#06b6d4', '#ec4899', '#fbbf24', '#10b981'],
-    duration: 600,
-  });
-}
-
-async function animateFadeQuiet(el) {
-  if (!el) return;
-  el.style.transition = 'opacity 0.3s ease-out';
-  el.style.opacity = '0.5';
-  await sleep(300);
-  el.style.opacity = '1';
-  await sleep(300);
-  el.style.transition = '';
-  el.style.opacity = '';
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/frontend/src/composables/useThemeAnimation.js
+++ b/frontend/src/composables/useThemeAnimation.js
@@ -117,16 +117,22 @@ export function animateSinkBounce(cardEl, oldRect) {
  * @returns {Promise<void>}
  */
 export async function animateBurstParticles(el) {
-  if (!el) return;
-  const rect = el.getBoundingClientRect();
-  const { spawnParticles } = await import('../utils/particles.js');
-  await spawnParticles({
-    x: rect.left + rect.width / 2,
-    y: rect.top + rect.height / 2,
-    count: 12,
-    colors: ['#06b6d4', '#ec4899', '#fbbf24', '#10b981'],
-    duration: 600,
-  });
+  try {
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const { spawnParticles } = await import('../utils/particles.js');
+    await spawnParticles({
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+      count: 12,
+      colors: ['#06b6d4', '#ec4899', '#fbbf24', '#10b981'],
+      duration: 600,
+    });
+  } catch {
+    // Particles are optional flair — never let their failure abort the
+    // sink-bounce wait in Promise.all (which would cause the reward popup
+    // to open mid-animation in Dashboard.vue).
+  }
 }
 
 /**

--- a/frontend/src/composables/useThemeAnimation.js
+++ b/frontend/src/composables/useThemeAnimation.js
@@ -182,7 +182,12 @@ export function useThemeAnimation() {
     /** Reactive hover micro-interaction class. */
     hoverClass,
 
-    /** Delegates to the standalone named export — behavior is now global. */
+    /**
+     * Delegates to the standalone named export — behavior is now global.
+     * @param {HTMLElement} cardEl
+     * @param {{ oldRect?: DOMRect|null, gotReward?: boolean }} opts
+     * @returns {Promise<void>}
+     */
     triggerCompletionCelebration,
   };
 }

--- a/frontend/src/composables/useThemeAnimation.js
+++ b/frontend/src/composables/useThemeAnimation.js
@@ -94,6 +94,8 @@ export function animateSinkBounce(cardEl, oldRect) {
     const deltaX = oldRect ? oldRect.left - newRect.left : 0;
     const deltaY = oldRect ? oldRect.top - newRect.top : 0;
     const anim = cardEl.animate(
+      // Translate from old slot → overshoot 20px past resting Y at 55% →
+      // bounce back to -4px at 80% → settle at (0, 0).
       [
         { transform: `translate(${deltaX}px, ${deltaY}px)` },
         { transform: 'translate(0, 20px)', offset: 0.55 },
@@ -106,6 +108,8 @@ export function animateSinkBounce(cardEl, oldRect) {
     );
     return anim.finished
       .catch(() => undefined)
+      // cancel() after `finished` settles releases the Animation object
+      // so it doesn't keep holding inline styles via fill: 'both'.
       .finally(() => anim.cancel?.());
   } catch {
     return Promise.resolve();

--- a/frontend/src/composables/useThemeAnimation.js
+++ b/frontend/src/composables/useThemeAnimation.js
@@ -100,6 +100,8 @@ export function animateSinkBounce(cardEl, oldRect) {
         { transform: 'translate(0, -4px)', offset: 0.8 },
         { transform: 'translate(0, 0)' },
       ],
+      // Overshoot-settle easing: the y=1.56 control point produces the
+      // ~20px overshoot at frame 0.55 before snapping back to 0.
       { duration: 600, easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)', fill: 'both' }
     );
     return anim.finished

--- a/frontend/src/composables/useThemeAnimation.js
+++ b/frontend/src/composables/useThemeAnimation.js
@@ -145,8 +145,7 @@ export async function animateBurstParticles(el) {
  */
 export function triggerCompletionCelebration(cardEl, opts = {}) {
   const { oldRect = null, gotReward = false } = opts;
-  if (typeof window !== 'undefined'
-    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+  if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
     return Promise.resolve();
   }
   const tasks = [animateSinkBounce(cardEl, oldRect)];

--- a/frontend/src/composables/useThemeAnimation.js
+++ b/frontend/src/composables/useThemeAnimation.js
@@ -145,7 +145,7 @@ export async function animateBurstParticles(el) {
  */
 export function triggerCompletionCelebration(cardEl, opts = {}) {
   const { oldRect = null, gotReward = false } = opts;
-  if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+  if (typeof window !== 'undefined' && (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false)) {
     return Promise.resolve();
   }
   const tasks = [animateSinkBounce(cardEl, oldRect)];

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, onUnmounted } from "vue";
+import { ref, reactive, computed, onUnmounted, nextTick } from "vue";
 import { router } from "@inertiajs/vue3";
 import HabitCard from "../components/HabitCard.vue";
 import UndoToast from "../components/UndoToast.vue";
@@ -129,20 +129,32 @@ function completeHabit(habitId) {
     realtimePauseTimer = null;
   }, 4000);
 
+  // Capture old position BEFORE the server response repositions the card.
+  const preCardComponent = cardRefs[habitId];
+  const preCardEl = preCardComponent?.cardRef;
+  const oldRect = preCardEl?.getBoundingClientRect?.() ?? null;
+
   router.post(`/habits/${habitId}/complete/`, {}, {
     preserveScroll: true,
-    onSuccess: (page) => {
+    onSuccess: async (page) => {
       const flash = page.props.completionFlash;
 
-      // Trigger card animation (scale-up / particles on the card itself)
+      // Wait for Inertia's new habits prop to be applied so the card sits in
+      // its new (bottom) DOM slot. Same :key keeps the same node — preCardEl
+      // is still valid for the FLIP delta.
+      await nextTick();
+
       const cardComponent = cardRefs[habitId];
-      const cardEl = cardComponent?.cardRef;
-      if (cardEl) {
-        triggerCompletionCelebration(cardEl);
+      const cardEl = cardComponent?.cardRef ?? preCardEl;
+      const gotReward = !!(flash?.got_reward && flash?.reward_name);
+
+      try {
+        await triggerCompletionCelebration(cardEl, { oldRect, gotReward });
+      } catch {
+        // Swallow — never block popup/undo on animation failure.
       }
 
-      // Show reward celebration if a reward was earned
-      if (flash?.got_reward && flash?.reward_name) {
+      if (gotReward) {
         celebrationData.rewardName = flash.reward_name;
         celebrationData.piecesEarned = flash.pieces_earned ?? null;
         celebrationData.piecesRequired = flash.pieces_required ?? null;

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -67,6 +67,9 @@ defineProps({
 const { themeConfig } = useTheme();
 const { triggerCompletionCelebration } = useThemeAnimation();
 
+// Covers the ~600ms sink-bounce + popup-display window.
+const REALTIME_PAUSE_DURATION_MS = 4000;
+
 // Pause realtime sync during celebration to prevent router.reload() from
 // resetting celebrationVisible before the user sees the reward popup.
 const realtimePaused = ref(false);
@@ -127,7 +130,7 @@ function completeHabit(habitId) {
   realtimePauseTimer = setTimeout(() => {
     realtimePaused.value = false;
     realtimePauseTimer = null;
-  }, 4000);
+  }, REALTIME_PAUSE_DURATION_MS);
 
   // Capture old position BEFORE the server response repositions the card.
   const preCardComponent = cardRefs[habitId];
@@ -144,14 +147,19 @@ function completeHabit(habitId) {
       // is still valid for the FLIP delta.
       await nextTick();
 
+      // Re-resolve the card component in case its mount/unmount churned during
+      // the Inertia re-render; fall back to the pre-post element we captured
+      // for the FLIP delta. Same :key normally keeps the DOM node stable.
       const cardComponent = cardRefs[habitId];
       const cardEl = cardComponent?.cardRef ?? preCardEl;
       const gotReward = !!(flash?.got_reward && flash?.reward_name);
 
       try {
         await triggerCompletionCelebration(cardEl, { oldRect, gotReward });
-      } catch {
-        // Swallow — never block popup/undo on animation failure.
+      } catch (err) {
+        // Universal fallback — inner animations swallow their own failures;
+        // this guards against any new rejection path. Surface in dev.
+        if (import.meta.env.DEV) console.warn('Completion animation failed:', err);
       }
 
       if (gotReward) {

--- a/frontend/src/pages/Theme.vue
+++ b/frontend/src/pages/Theme.vue
@@ -288,8 +288,8 @@ function getPersonalityTags(id) {
 
   // Animation highlights
   const anims = config.animations || {};
-  if (anims.completionCelebration === 'burst-particles') tags.push('Particles');
-  else if (anims.completionCelebration === 'fade-quiet') tags.push('Quiet');
+  if (config.reward?.rewardPopupVariant === 'particles') tags.push('Particles');
+  else if (config.reward?.rewardPopupVariant === 'quiet') tags.push('Quiet');
 
   if (anims.cardEntrance === 'slide-up') tags.push('Slide');
   else if (anims.cardEntrance === 'stagger-fade') tags.push('Stagger');

--- a/frontend/src/themes/index.js
+++ b/frontend/src/themes/index.js
@@ -16,8 +16,8 @@
  *  - navStyle      'default' | 'frosted' | 'underline' | 'glow'
  *  - font          { family, import, weight, size }
  *  - interactions  { habitComplete }
- *  - animations    { cardEntrance, completionCelebration, hoverMicro, streakFire }
- *  - reward        { displayMode, celebrationComponent }
+ *  - animations    { cardEntrance, hoverMicro, streakFire }
+ *  - reward        { displayMode, celebrationComponent, rewardPopupVariant }
  *  - pageLayout    { habitList, density, rewardList }
  */
 
@@ -30,8 +30,8 @@ export const VALID_CARD_ENTRANCES = new Set([
   'none', 'fade-in', 'slide-up', 'stagger-fade',
 ]);
 
-export const VALID_COMPLETION_CELEBRATIONS = new Set([
-  'none', 'scale-up', 'burst-particles', 'fade-quiet',
+export const VALID_REWARD_POPUP_VARIANTS = new Set([
+  'default', 'particles', 'quiet',
 ]);
 
 export const VALID_HOVER_MICROS = new Set([
@@ -67,13 +67,13 @@ export const DEFAULTS = {
   },
   animations: {
     cardEntrance: 'none',
-    completionCelebration: 'none',
     hoverMicro: 'none',
     streakFire: 'none',
   },
   reward: {
     displayMode: 'expand-from-card',
     celebrationComponent: null,
+    rewardPopupVariant: 'default',
   },
   pageLayout: {
     habitList: 'list',
@@ -163,13 +163,13 @@ export const themes = {
     },
     animations: {
       cardEntrance: 'fade-in',
-      completionCelebration: 'scale-up',
       hoverMicro: 'shadow-lift',
       streakFire: 'pulse-glow',
     },
     reward: {
       displayMode: 'expand-from-card',
       celebrationComponent: null,
+      rewardPopupVariant: 'default',
     },
     pageLayout: {
       habitList: 'list',
@@ -232,13 +232,13 @@ export const themes = {
     },
     animations: {
       cardEntrance: 'stagger-fade',
-      completionCelebration: 'burst-particles',
       hoverMicro: 'glow-border',
       streakFire: 'flicker-flame',
     },
     reward: {
       displayMode: 'toast',
       celebrationComponent: null,
+      rewardPopupVariant: 'particles',
     },
     pageLayout: {
       habitList: 'list',
@@ -300,13 +300,13 @@ export const themes = {
     },
     animations: {
       cardEntrance: 'slide-up',
-      completionCelebration: 'scale-up',
       hoverMicro: 'scale',
       streakFire: 'bounce',
     },
     reward: {
       displayMode: 'expand-from-card',
       celebrationComponent: null,
+      rewardPopupVariant: 'default',
     },
     pageLayout: {
       habitList: 'list',
@@ -369,13 +369,13 @@ export const themes = {
     },
     animations: {
       cardEntrance: 'fade-in',
-      completionCelebration: 'scale-up',
       hoverMicro: 'scale',
       streakFire: 'pulse-glow',
     },
     reward: {
       displayMode: 'expand-from-card',
       celebrationComponent: null,
+      rewardPopupVariant: 'default',
     },
     pageLayout: {
       habitList: 'list',
@@ -438,13 +438,13 @@ export const themes = {
     },
     animations: {
       cardEntrance: 'fade-in',
-      completionCelebration: 'fade-quiet',
       hoverMicro: 'none',
       streakFire: 'pulse-glow',
     },
     reward: {
       displayMode: 'expand-from-card',
       celebrationComponent: null,
+      rewardPopupVariant: 'quiet',
     },
     pageLayout: {
       habitList: 'list',
@@ -508,13 +508,13 @@ export const themes = {
     },
     animations: {
       cardEntrance: 'stagger-fade',
-      completionCelebration: 'fade-quiet',
       hoverMicro: 'glow-border',
       streakFire: 'flicker-flame',
     },
     reward: {
       displayMode: 'toast',
       celebrationComponent: null,
+      rewardPopupVariant: 'quiet',
     },
     pageLayout: {
       habitList: 'list',
@@ -577,13 +577,13 @@ export const themes = {
     },
     animations: {
       cardEntrance: 'slide-up',
-      completionCelebration: 'scale-up',
       hoverMicro: 'shadow-lift',
       streakFire: 'bounce',
     },
     reward: {
       displayMode: 'expand-from-card',
       celebrationComponent: null,
+      rewardPopupVariant: 'default',
     },
     pageLayout: {
       habitList: 'list',
@@ -646,13 +646,13 @@ export const themes = {
     },
     animations: {
       cardEntrance: 'none',
-      completionCelebration: 'fade-quiet',
       hoverMicro: 'none',
       streakFire: 'none',
     },
     reward: {
       displayMode: 'expand-from-card',
       celebrationComponent: null,
+      rewardPopupVariant: 'quiet',
     },
     pageLayout: {
       habitList: 'list',

--- a/frontend/tests/themeAnimation.spec.js
+++ b/frontend/tests/themeAnimation.spec.js
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  animateSinkBounce,
+  triggerCompletionCelebration,
+} from "../src/composables/useThemeAnimation.js";
+
+// Spy used by all tests to observe animate() calls.
+let animateSpy;
+// Stub returned by animate(); each test can swap finished/throw behaviour.
+let animationStub;
+
+function makeCardEl(rect = { top: 0, left: 0, width: 200, height: 80 }) {
+  return {
+    getBoundingClientRect: () => ({
+      ...rect,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+    }),
+    animate: animateSpy,
+  };
+}
+
+vi.mock("../src/utils/particles.js", () => ({
+  spawnParticles: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { spawnParticles } from "../src/utils/particles.js";
+
+beforeEach(() => {
+  animationStub = {
+    finished: Promise.resolve(),
+    cancel: vi.fn(),
+  };
+  animateSpy = vi.fn(() => animationStub);
+  // Default: reduced-motion off
+  window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("animateSinkBounce", () => {
+  it("resolves after the Web Animation finishes", async () => {
+    const cardEl = makeCardEl({ top: 100, left: 0, width: 200, height: 80 });
+    const oldRect = { top: 40, left: 0, width: 200, height: 80 };
+
+    const p = animateSinkBounce(cardEl, oldRect);
+    await expect(p).resolves.toBeUndefined();
+
+    expect(animateSpy).toHaveBeenCalledTimes(1);
+    const [keyframes, options] = animateSpy.mock.calls[0];
+    expect(keyframes[0].transform).toBe("translate(0px, -60px)");
+    expect(keyframes[keyframes.length - 1].transform).toBe("translate(0, 0)");
+    expect(options.duration).toBe(600);
+  });
+
+  it("no-ops with missing element", async () => {
+    await expect(animateSinkBounce(null, { top: 0, left: 0 })).resolves.toBeUndefined();
+    expect(animateSpy).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when WAAPI is missing", async () => {
+    const el = { getBoundingClientRect: () => ({ top: 0, left: 0 }) };
+    await expect(animateSinkBounce(el, { top: 10, left: 0 })).resolves.toBeUndefined();
+    expect(animateSpy).not.toHaveBeenCalled();
+  });
+
+  it("swallows animate() sync throws", async () => {
+    animateSpy = vi.fn(() => {
+      throw new Error("nope");
+    });
+    const el = makeCardEl({ top: 50, left: 0, width: 100, height: 30 });
+    await expect(animateSinkBounce(el, { top: 0, left: 0 })).resolves.toBeUndefined();
+  });
+
+  it("swallows finished promise rejection (AbortError)", async () => {
+    animationStub = {
+      finished: Promise.reject(new Error("Aborted")),
+      cancel: vi.fn(),
+    };
+    animateSpy = vi.fn(() => animationStub);
+    const el = makeCardEl();
+    await expect(animateSinkBounce(el, { top: 0, left: 0 })).resolves.toBeUndefined();
+  });
+
+  it("handles missing oldRect (renders an in-place mini-bounce)", async () => {
+    const el = makeCardEl({ top: 50, left: 50, width: 200, height: 80 });
+    await animateSinkBounce(el, null);
+    const [keyframes] = animateSpy.mock.calls[0];
+    expect(keyframes[0].transform).toBe("translate(0px, 0px)");
+  });
+
+  it("composes horizontal + vertical delta correctly", async () => {
+    const el = makeCardEl({ top: 40, left: 50, width: 200, height: 80 });
+    const oldRect = { top: 0, left: 100, width: 200, height: 80 };
+    await animateSinkBounce(el, oldRect);
+    const [keyframes] = animateSpy.mock.calls[0];
+    expect(keyframes[0].transform).toBe("translate(50px, -40px)");
+    expect(keyframes[keyframes.length - 1].transform).toBe("translate(0, 0)");
+  });
+});
+
+describe("triggerCompletionCelebration", () => {
+  it("invokes only sink when gotReward is false", async () => {
+    const el = makeCardEl();
+    await triggerCompletionCelebration(el, {
+      oldRect: { top: 0, left: 0 },
+      gotReward: false,
+    });
+    expect(animateSpy).toHaveBeenCalledTimes(1);
+    expect(spawnParticles).not.toHaveBeenCalled();
+  });
+
+  it("invokes both sink and particle burst when gotReward is true", async () => {
+    const el = makeCardEl();
+    await triggerCompletionCelebration(el, {
+      oldRect: { top: 0, left: 0 },
+      gotReward: true,
+    });
+    expect(animateSpy).toHaveBeenCalledTimes(1);
+    expect(spawnParticles).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips animations entirely under prefers-reduced-motion", async () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+    const el = makeCardEl();
+    await triggerCompletionCelebration(el, {
+      oldRect: { top: 0, left: 0 },
+      gotReward: true,
+    });
+    expect(animateSpy).not.toHaveBeenCalled();
+    expect(spawnParticles).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/themeAnimation.spec.js
+++ b/frontend/tests/themeAnimation.spec.js
@@ -132,4 +132,33 @@ describe("triggerCompletionCelebration", () => {
     expect(animateSpy).not.toHaveBeenCalled();
     expect(spawnParticles).not.toHaveBeenCalled();
   });
+
+  it("particle rejection does not abort the sink animation wait", async () => {
+    // Sink finishes after particles reject. Promise.all-without-catch would
+    // reject early and Dashboard.vue's catch would open the popup before the
+    // sink settled — guarded by animateBurstParticles' internal try/catch.
+    let resolveSink;
+    animationStub = {
+      finished: new Promise((r) => { resolveSink = r; }),
+      cancel: vi.fn(),
+    };
+    animateSpy = vi.fn(() => animationStub);
+    spawnParticles.mockRejectedValueOnce(new Error("particle failure"));
+
+    const el = makeCardEl();
+    let resolved = false;
+    const p = triggerCompletionCelebration(el, {
+      oldRect: { top: 0, left: 0 },
+      gotReward: true,
+    }).then(() => { resolved = true; });
+
+    // Let the particle rejection propagate through microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    resolveSink();
+    await p;
+    expect(resolved).toBe(true);
+  });
 });

--- a/frontend/tests/themeAnimation.spec.js
+++ b/frontend/tests/themeAnimation.spec.js
@@ -9,6 +9,7 @@ let animateSpy;
 // Stub returned by animate(); each test can swap finished/throw behaviour.
 let animationStub;
 
+/** @param {{top: number, left: number, width: number, height: number}} [rect] */
 function makeCardEl(rect = { top: 0, left: 0, width: 200, height: 80 }) {
   return {
     getBoundingClientRect: () => ({

--- a/frontend/tests/themes.spec.js
+++ b/frontend/tests/themes.spec.js
@@ -7,7 +7,7 @@ import {
   DEFAULTS,
   VALID_INTERACTIONS,
   VALID_CARD_ENTRANCES,
-  VALID_COMPLETION_CELEBRATIONS,
+  VALID_REWARD_POPUP_VARIANTS,
   VALID_HOVER_MICROS,
   VALID_STREAK_FIRES,
   VALID_DISPLAY_MODES,
@@ -59,12 +59,15 @@ describe("Theme config schema", () => {
 
         expect(config).toHaveProperty("animations");
         expect(config.animations).toHaveProperty("cardEntrance");
-        expect(config.animations).toHaveProperty("completionCelebration");
         expect(config.animations).toHaveProperty("hoverMicro");
         expect(config.animations).toHaveProperty("streakFire");
+        // Forward-compat guard: deprecated key must not reappear via DEFAULTS
+        // leakage or a raw theme block (deepMerge preserves unknown keys).
+        expect("completionCelebration" in config.animations).toBe(false);
 
         expect(config).toHaveProperty("reward");
         expect(config.reward).toHaveProperty("displayMode");
+        expect(config.reward).toHaveProperty("rewardPopupVariant");
 
         expect(config).toHaveProperty("pageLayout");
         expect(config.pageLayout).toHaveProperty("habitList");
@@ -78,7 +81,7 @@ describe("Theme config schema", () => {
 
       it("uses valid values for animations", () => {
         expect(VALID_CARD_ENTRANCES.has(config.animations.cardEntrance)).toBe(true);
-        expect(VALID_COMPLETION_CELEBRATIONS.has(config.animations.completionCelebration)).toBe(true);
+        expect(VALID_REWARD_POPUP_VARIANTS.has(config.reward.rewardPopupVariant)).toBe(true);
         expect(VALID_HOVER_MICROS.has(config.animations.hoverMicro)).toBe(true);
         expect(VALID_STREAK_FIRES.has(config.animations.streakFire)).toBe(true);
       });
@@ -88,6 +91,15 @@ describe("Theme config schema", () => {
         expect(VALID_HABIT_LAYOUTS.has(config.pageLayout.habitList)).toBe(true);
         expect(VALID_DENSITIES.has(config.pageLayout.density)).toBe(true);
       });
+    });
+  }
+});
+
+describe("Deprecated keys", () => {
+  // Diagnostic clarity: pinpoint the offending raw theme block on regression.
+  for (const [id, raw] of Object.entries(themes)) {
+    it(`raw theme "${id}" does not redeclare completionCelebration`, () => {
+      expect("completionCelebration" in (raw.animations ?? {})).toBe(false);
     });
   }
 });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7,3 +7,11 @@
 ### Adopt CHANGELOG.md convention
 
 Raised by claude-review on PR #46 (P3 DOCS): user-facing changes should land in a `CHANGELOG.md`. No changelog file currently exists in the repo, so adopting one is a project-wide convention decision rather than per-PR scope. Decide whether to introduce `CHANGELOG.md` (Keep-a-Changelog format is the obvious default) and, if so, backfill recent user-facing entries.
+
+### Dashboard.vue integration test for habit-completion flow
+
+Raised by claude-review on PR #58 (P2 TESTING). Add a component-level test for `Dashboard.vue` `completeHabit` that asserts (1) `oldRect` is captured before the POST, (2) `nextTick` is awaited, (3) `triggerCompletionCelebration` is called with the correct `{ oldRect, gotReward }` payload, (4) the celebration popup is only opened when `gotReward` is true. Needs Inertia `router.post` mocking plus stubs for `useTheme`, `useThemeAnimation`, `useRealtimeSync`, and child components — substantial enough to warrant its own focused PR.
+
+### HabitCard.vue swipe-mode ref placement regression test
+
+Raised by claude-review on PR #58 (P2 TESTING). Mount `HabitCard.vue` with `interactions.habitComplete: 'swipe-reveal'` and assert the exposed `cardRef` is a real DOM element with a callable `getBoundingClientRect`, not a Vue component proxy. Pins the fix from PR #58 (the swipe-mode `ref` was previously bound to the `<HabitDoneSwipe>` component, breaking `animate()` in swipe mode). Requires stubbing `useTheme` + child interaction components.


### PR DESCRIPTION
## Summary
- Global FLIP-based sink-bounce animation when a habit is marked done (600ms, overshoot-settle cubic-bezier). Card travels from its old slot to its new bottom slot, then the reward popup opens (only if a reward was actually earned). Particle burst plays in parallel on reward wins.
- Theme schema migration: `animations.completionCelebration` → `reward.rewardPopupVariant` (semantically accurate — the field now only drives popup-component selection). All 8 themes migrated.
- Fixes pre-existing swipe-mode bug where `ref="cardRef"` was bound to a Vue component proxy instead of the DOM element — broke `getBoundingClientRect()` / `animate()` for swipe interactions.
- Resilience: reduced-motion gate, WAAPI-missing fallback, animation errors never block popup/undo (wrapped in try/catch in Dashboard).

See [`docs/features/0046_PLAN.md`](docs/features/0046_PLAN.md) for the full design rationale.

## Test plan
- [x] `npx vitest run` — 10 new tests in `themeAnimation.spec.js`, themes spec passes (incl. forward-compat guards against deprecated key reintroduction)
- [x] `npm run build` — clean production build
- [ ] Manual: complete a habit without reward → sink-bounce, no popup, undo toast
- [ ] Manual: complete a habit with reward → sink-bounce + particles → popup → undo toast
- [ ] Manual: complete via swipe interaction → animation still plays (verifies ref-placement fix)
- [ ] Manual: enable `prefers-reduced-motion` → no animation, popup (if any) appears immediately
- [ ] Manual: each theme renders its expected reward popup variant (Particles / Quiet / Default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)