### PR TITLE
fix: delete /remove_habit command message on manual entry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -184,6 +184,10 @@ This document tracks planned features, improvements, and enhancements for the Ha
 
 ## 🐛 Bug Fixes & Technical Debt
 
+- [x] **Delete `/remove_habit` command message from chat**
+  - Menu path fixed in PR #60; manual `/remove_habit` deletes the command message in `remove_habit_command` after validation
+  - **File**: `src/bot/handlers/habit_management_handler.py` (`remove_habit_command`)
+
 - [ ] **Review and Refactor**
   - Code review for consistency
   - Remove deprecated code paths

--- a/src/bot/handlers/habit_management_handler.py
+++ b/src/bot/handlers/habit_management_handler.py
@@ -1491,6 +1491,14 @@ async def remove_habit_command(update: Update, context: ContextTypes.DEFAULT_TYP
         logger.info(f"📤 Sent ERROR_NO_HABITS_TO_REMOVE to {telegram_id}")
         return ConversationHandler.END
 
+    try:
+        await update.message.delete()
+        logger.info(f"🗑️ Deleted /remove_habit command message for user {telegram_id}")
+    except Exception as e:
+        logger.warning(
+            f"⚠️ Could not delete /remove_habit command message for user {telegram_id}: {e}"
+        )
+
     # Show habit selection keyboard
     keyboard = build_habits_for_edit_keyboard(habits, operation="remove", language=lang)
     await update.message.reply_text(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,3 +15,7 @@ Raised by claude-review on PR #58 (P2 TESTING). Add a component-level test for `
 ### HabitCard.vue swipe-mode ref placement regression test
 
 Raised by claude-review on PR #58 (P2 TESTING). Mount `HabitCard.vue` with `interactions.habitComplete: 'swipe-reveal'` and assert the exposed `cardRef` is a real DOM element with a callable `getBoundingClientRect`, not a Vue component proxy. Pins the fix from PR #58 (the swipe-mode `ref` was previously bound to the `<HabitDoneSwipe>` component, breaking `animate()` in swipe mode). Requires stubbing `useTheme` + child interaction components.
+
+### Narrow broad `except Exception` to `telegram.error.TelegramError` in habit_management_handler
+
+Raised by claude-review on PR #64 (P3 QUALITY). The deletion try/except at `src/bot/handlers/habit_management_handler.py:1494` uses a broad `except Exception`. The reviewer notes the change "should be applied consistently across the file, not just in this one location" — i.e. a file-wide refactor of every defensive `except Exception` block that wraps a `python-telegram-bot` API call (importing `from telegram import error` and catching `telegram.error.TelegramError`). Scope is much larger than this PR; deserves its own focused PR that audits all such blocks, decides whether `TelegramError` is genuinely the only expected class (vs. e.g. asyncio cancellation), and updates them uniformly.

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -650,6 +650,36 @@ class TestRemoveHabitCommand:
         assert result == ConversationHandler.END
         mock_telegram_update.message.delete.assert_not_called()
 
+    @pytest.mark.asyncio
+    @patch('src.bot.handlers.habit_management_handler.logger')
+    @patch('src.bot.handlers.habit_management_handler.user_repository')
+    @patch('src.bot.handlers.habit_management_handler.habit_repository')
+    async def test_command_continues_when_deletion_fails(
+        self,
+        mock_habit_repo,
+        mock_user_repo,
+        mock_logger,
+        mock_telegram_update,
+        mock_active_user,
+        language,
+    ):
+        """Deletion failure must not break the flow: keyboard still sent, state advances."""
+        mock_user_repo.get_by_telegram_id.return_value = mock_active_user
+        mock_habit_repo.get_all_active.return_value = [
+            Habit(id='h1', name='Morning run', weight=10, category='fitness', active=True)
+        ]
+        mock_telegram_update.message.delete.side_effect = Exception("Permission denied")
+
+        result = await remove_habit_command(mock_telegram_update, context=Mock(user_data={}))
+
+        assert result == AWAITING_REMOVE_SELECTION
+        mock_telegram_update.message.delete.assert_called_once()
+        mock_telegram_update.message.reply_text.assert_called_once()
+        assert any(
+            "Could not delete /remove_habit command message" in str(call.args[0])
+            for call in mock_logger.warning.call_args_list
+        ), f"Expected deletion-failure warning, got: {mock_logger.warning.call_args_list}"
+
 
 class TestRemoveHabitBack:
     @pytest.mark.asyncio

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -39,6 +39,7 @@ from src.bot.handlers.menu_handler import (
 )
 from src.bot.handlers.habit_management_handler import (
     remove_back_to_list,
+    remove_habit_command,
     AWAITING_REMOVE_SELECTION,
     AWAITING_HABIT_NAME,
     habit_remove_confirmed,
@@ -91,6 +92,7 @@ def mock_telegram_update(mock_telegram_user):
     """Create mock Telegram update with message."""
     message = Mock(spec=Message)
     message.reply_text = AsyncMock()
+    message.delete = AsyncMock()
 
     update = Mock(spec=Update)
     update.effective_user = mock_telegram_user
@@ -613,6 +615,40 @@ class TestSimpleHabitDoneFlow:
 
         # Assert: returned 0
         assert result == 0
+
+
+class TestRemoveHabitCommand:
+    @pytest.mark.asyncio
+    @patch('src.bot.handlers.habit_management_handler.user_repository')
+    @patch('src.bot.handlers.habit_management_handler.habit_repository')
+    async def test_command_message_deleted_when_habits_exist(
+        self, mock_habit_repo, mock_user_repo, mock_telegram_update, mock_active_user, language
+    ):
+        """Manual /remove_habit should not leave the command text in chat (issue #59)."""
+        mock_user_repo.get_by_telegram_id.return_value = mock_active_user
+        mock_habit_repo.get_all_active.return_value = [
+            Habit(id='h1', name='Morning run', weight=10, category='fitness', active=True)
+        ]
+
+        result = await remove_habit_command(mock_telegram_update, context=Mock(user_data={}))
+
+        assert result == AWAITING_REMOVE_SELECTION
+        mock_telegram_update.message.delete.assert_called_once()
+        mock_telegram_update.message.reply_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch('src.bot.handlers.habit_management_handler.user_repository')
+    @patch('src.bot.handlers.habit_management_handler.habit_repository')
+    async def test_command_message_not_deleted_when_no_habits(
+        self, mock_habit_repo, mock_user_repo, mock_telegram_update, mock_active_user, language
+    ):
+        mock_user_repo.get_by_telegram_id.return_value = mock_active_user
+        mock_habit_repo.get_all_active.return_value = []
+
+        result = await remove_habit_command(mock_telegram_update, context=Mock(user_data={}))
+
+        assert result == ConversationHandler.END
+        mock_telegram_update.message.delete.assert_not_called()
 
 
 class TestRemoveHabitBack:


### PR DESCRIPTION
## Summary

Completes [#59](https://github.com/erzhan12/habit-reward/issues/59) for the **manual command** path. PR #60 fixed the Habits menu (no visible `/remove_habit` text); this PR deletes the user's command message when they type `/remove_habit` directly.

## Changes

- `remove_habit_command`: after validation (user active, has habits), call `update.message.delete()` before showing the habit selection keyboard
- Tests: `TestRemoveHabitCommand` — delete on success path, no delete when no habits
- Rebased on `main` (includes PR #60 + #61)

## Test plan

- [x] `uv run pytest tests/test_bot_handlers.py::TestRemoveHabitCommand -q`
- [ ] Manual: type `/remove_habit` in Telegram — command bubble disappears, selection flow works
- [ ] Manual: Habits menu → Remove — still no `/remove_habit` text (regression from #60)

Fixes #59

Made with [Cursor](https://cursor.com)