### PR TITLE
feat: add Night Arcade, Ticket Stub, and Quest Log themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 
 # Python
 __pycache__/
+.django_cache/
 *.py[cod]
 *$py.class
 *.so

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -124,3 +124,42 @@ body {
   --color-danger: #dc2626;
   --color-streak-fire: #d97706;
 }
+
+[data-theme="night_arcade"] {
+  --color-bg-primary: #0d0e13;
+  --color-bg-card: #161821;
+  --color-bg-card-hover: #1c1f2b;
+  --color-text-primary: #eef0f6;
+  --color-text-secondary: #9aa1b5;
+  --color-text-muted: #6f7688;
+  --color-accent: #e9b953;
+  --color-accent-hover: #f3d27e;
+  --color-danger: #ef4444;
+  --color-streak-fire: #f97316;
+}
+
+[data-theme="ticket_stub"] {
+  --color-bg-primary: #f5f1e8;
+  --color-bg-card: #fffdf8;
+  --color-bg-card-hover: #fdf8ee;
+  --color-text-primary: #2a2620;
+  --color-text-secondary: #6b6354;
+  --color-text-muted: #9a9080;
+  --color-accent: #d95d39;
+  --color-accent-hover: #e5714e;
+  --color-danger: #c0392b;
+  --color-streak-fire: #e07b39;
+}
+
+[data-theme="quest_log"] {
+  --color-bg-primary: #0e1411;
+  --color-bg-card: #111a15;
+  --color-bg-card-hover: #16241c;
+  --color-text-primary: #eef5f0;
+  --color-text-secondary: #7d8f84;
+  --color-text-muted: #546158;
+  --color-accent: #56c288;
+  --color-accent-hover: #7ad3a3;
+  --color-danger: #e05d5d;
+  --color-streak-fire: #e07b39;
+}

--- a/frontend/src/components/DashboardHeader.vue
+++ b/frontend/src/components/DashboardHeader.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="mb-6">
+    <!-- ═══ ring (Night Arcade): progress ring + points ═══ -->
+    <div v-if="headerStyle === 'ring'" class="flex items-center gap-5">
+      <div class="w-16 h-16 rounded-full grid place-items-center shrink-0" :style="ringStyle">
+        <div class="w-[52px] h-[52px] rounded-full grid place-items-center bg-bg-primary">
+          <span class="font-bold text-[15px] text-text-primary"
+            >{{ stats.completedToday }}<span class="text-text-muted font-medium">/{{ stats.totalToday }}</span></span
+          >
+        </div>
+      </div>
+      <div>
+        <h1 class="text-2xl font-bold text-text-primary">Today</h1>
+        <p class="text-sm text-text-secondary mt-0.5">
+          {{ dateLabel }}
+          <span v-if="stats.totalPointsToday > 0" class="text-accent font-semibold">
+            · +{{ stats.totalPointsToday }} pts</span
+          >
+        </p>
+      </div>
+    </div>
+
+    <!-- ═══ punches (Ticket Stub): weekday + punch tally ═══ -->
+    <div v-else-if="headerStyle === 'punches'" class="flex items-end gap-5">
+      <div>
+        <h1 class="text-[26px] font-bold text-text-primary tracking-tight">{{ weekdayLabel }}</h1>
+        <p class="text-sm text-text-secondary mt-0.5">
+          {{ dateLabel }}
+          <span v-if="stats.totalPointsToday > 0" class="text-accent font-semibold">
+            · +{{ stats.totalPointsToday }} pts</span
+          >
+        </p>
+      </div>
+      <div class="ml-auto flex items-center gap-2.5 pb-1">
+        <span class="text-xs text-text-secondary font-medium">Today's punches</span>
+        <div class="flex gap-1.5">
+          <span
+            v-for="i in stats.totalToday"
+            :key="i"
+            class="w-4 h-4 rounded-full grid place-items-center"
+            :class="i <= stats.completedToday
+              ? 'bg-accent text-white text-[10px]'
+              : 'border-[1.5px] border-dashed border-text-muted'"
+            >{{ i <= stats.completedToday ? '✓' : '' }}</span
+          >
+        </div>
+      </div>
+    </div>
+
+    <!-- ═══ xp (Quest Log): stat line + progress bar ═══ -->
+    <div v-else-if="headerStyle === 'xp'" class="bg-bg-card border border-bg-card-hover rounded-lg px-4 py-3.5">
+      <div class="flex items-baseline gap-4">
+        <h1 class="text-[17px] font-semibold text-text-primary uppercase tracking-wide">
+          Today — {{ shortDateLabel }}
+        </h1>
+        <span class="text-xs text-text-secondary"
+          >quests: <span class="text-accent font-semibold">{{ stats.completedToday }}/{{ stats.totalToday }}</span></span
+        >
+        <span v-if="stats.totalPointsToday > 0" class="text-xs text-text-secondary"
+          >points: <span class="text-streak-fire font-semibold">+{{ stats.totalPointsToday }}</span></span
+        >
+      </div>
+      <div class="flex items-center gap-2.5 mt-2.5">
+        <div class="flex-1 h-2 rounded bg-bg-card-hover overflow-hidden">
+          <div class="h-full bg-accent transition-all duration-500" :style="{ width: pct + '%' }"></div>
+        </div>
+        <span class="text-[11px] text-text-secondary">{{ pct }}%</span>
+      </div>
+    </div>
+
+    <!-- ═══ plain (default, all existing themes) ═══ -->
+    <div v-else>
+      <h1 class="text-2xl font-bold text-text-primary mb-1">Today</h1>
+      <p class="text-sm text-text-secondary">
+        {{ stats.completedToday }} / {{ stats.totalToday }} habits done
+        <span v-if="stats.totalPointsToday > 0" class="ml-2 text-accent">
+          +{{ stats.totalPointsToday }}pts
+        </span>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useTheme } from "../composables/useTheme.js";
+
+const props = defineProps({
+  stats: { type: Object, default: () => ({ completedToday: 0, totalToday: 0, totalPointsToday: 0 }) },
+});
+
+const { themeConfig } = useTheme();
+
+const headerStyle = computed(() => themeConfig.value.pageLayout?.headerStyle || "plain");
+
+const pct = computed(() => {
+  const total = props.stats.totalToday || 0;
+  if (!total) return 0;
+  return Math.round((props.stats.completedToday / total) * 100);
+});
+
+// conic-gradient progress ring driven by the accent CSS var
+const ringStyle = computed(() => ({
+  background: `conic-gradient(var(--color-accent) 0 ${pct.value * 3.6}deg, var(--color-bg-card-hover) ${pct.value * 3.6}deg 360deg)`,
+}));
+
+const now = new Date();
+const weekdayLabel = now.toLocaleDateString("en-US", { weekday: "long" });
+const dateLabel = now.toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric" });
+const shortDateLabel = now
+  .toLocaleDateString("en-US", { month: "short", day: "2-digit" })
+  .toUpperCase();
+</script>

--- a/frontend/src/components/HabitCard.vue
+++ b/frontend/src/components/HabitCard.vue
@@ -9,7 +9,7 @@
   >
     <div
       ref="cardRef"
-      class="transition-all"
+      class="transition-opacity transition-shadow duration-200"
       :class="[
         densityPadding,
         tc.card.bg,
@@ -26,7 +26,7 @@
   <div
     v-else
     ref="cardRef"
-    class="transition-all"
+    class="transition-opacity transition-shadow duration-200"
     :class="[
       densityPadding,
       tc.card.rounded,

--- a/frontend/src/components/HabitCardContent.vue
+++ b/frontend/src/components/HabitCardContent.vue
@@ -7,10 +7,25 @@
       >
         {{ habit.name }}
       </h3>
-      <span class="text-xs px-1.5 py-0.5 shrink-0" :class="tc.badge.base">
+
+      <!-- odds badge: hidden by themes that keep the dashboard reward-free -->
+      <span v-if="hc.showOdds" class="text-xs px-1.5 py-0.5 shrink-0" :class="tc.badge.base">
         {{ habit.weight }}w · {{ habit.rewardChance }}%
       </span>
+
+      <!-- outcome chip: only on completed habits, only when the theme opts in -->
+      <span
+        v-if="hc.showOutcome && habit.completedToday && habit.todayResult"
+        class="text-xs px-1.5 py-0.5 shrink-0 font-medium rounded"
+        :class="habit.todayResult.gotReward ? 'text-accent' : 'text-text-muted'"
+      >
+        <template v-if="habit.todayResult.gotReward">
+          🎁 piece won<template v-if="habit.todayResult.rewardName"> — {{ habit.todayResult.rewardName }}</template>
+        </template>
+        <template v-else>no reward this time</template>
+      </span>
     </div>
+
     <div v-if="habit.streak > 0" class="flex items-center gap-1 mt-1">
       <span
         class="text-sm"
@@ -27,12 +42,23 @@
 
 <script setup>
 import { computed } from "vue";
+import { useTheme } from "../composables/useTheme.js";
 
 const props = defineProps({
   habit: { type: Object, required: true },
   tc: { type: Object, required: true },
   streakClass: { type: String, default: "" },
 });
+
+const { themeConfig } = useTheme();
+
+// habitCard theme config with safe defaults (matches DEFAULTS in themes/index.js)
+const hc = computed(() => ({
+  showOdds: true,
+  showOutcome: false,
+  buttonLabel: "Done",
+  ...(themeConfig.value.habitCard || {}),
+}));
 
 const streakColorClasses = computed(() => [
   props.habit.completedToday ? "text-text-muted" : "text-streak-fire",

--- a/frontend/src/components/interactions/HabitDoneButton.vue
+++ b/frontend/src/components/interactions/HabitDoneButton.vue
@@ -7,7 +7,7 @@
       class="text-sm font-medium transition-all disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
       :class="[tc.button.rounded, tc.button.padding, tc.button.primary]"
     >
-      Done
+      {{ buttonLabel }}
     </button>
     <button
       v-else
@@ -39,4 +39,5 @@ defineEmits(["complete", "revert"]);
 
 const { themeConfig } = useTheme();
 const tc = computed(() => themeConfig.value.classes);
+const buttonLabel = computed(() => themeConfig.value.habitCard?.buttonLabel || "Done");
 </script>

--- a/frontend/src/composables/useThemeAnimation.js
+++ b/frontend/src/composables/useThemeAnimation.js
@@ -126,12 +126,24 @@ export async function animateBurstParticles(el) {
   try {
     if (!el) return;
     const rect = el.getBoundingClientRect();
+    const accent = getComputedStyle(document.documentElement)
+      .getPropertyValue("--color-accent")
+      .trim();
+    const streak = getComputedStyle(document.documentElement)
+      .getPropertyValue("--color-streak-fire")
+      .trim();
+    const colors = [
+      accent || "#e9b953",
+      streak || "#f97316",
+      "#fbbf24",
+      "#10b981",
+    ];
     const { spawnParticles } = await import('../utils/particles.js');
     await spawnParticles({
       x: rect.left + rect.width / 2,
       y: rect.top + rect.height / 2,
       count: 12,
-      colors: ['#06b6d4', '#ec4899', '#fbbf24', '#10b981'],
+      colors,
       duration: 600,
     });
   } catch {

--- a/frontend/src/pages/Dashboard.vue
+++ b/frontend/src/pages/Dashboard.vue
@@ -1,15 +1,6 @@
 <template>
   <div class="px-4 pt-6 pb-4 max-w-2xl mx-auto">
-    <!-- Stats header -->
-    <div class="mb-6">
-      <h1 class="text-2xl font-bold text-text-primary mb-1">Today</h1>
-      <p class="text-sm text-text-secondary">
-        {{ stats.completedToday }} / {{ stats.totalToday }} habits done
-        <span v-if="stats.totalPointsToday > 0" class="ml-2 text-accent">
-          +{{ stats.totalPointsToday }}pts
-        </span>
-      </p>
-    </div>
+    <DashboardHeader :stats="stats" />
 
     <!-- Habit list / grid -->
     <div :class="listLayoutClass">
@@ -52,6 +43,7 @@
 import { ref, reactive, computed, onUnmounted, nextTick } from "vue";
 import { router } from "@inertiajs/vue3";
 import HabitCard from "../components/HabitCard.vue";
+import DashboardHeader from "../components/DashboardHeader.vue";
 import UndoToast from "../components/UndoToast.vue";
 import RewardCelebration from "../components/rewards/RewardCelebration.vue";
 import { useTheme } from "../composables/useTheme.js";
@@ -94,6 +86,19 @@ const listLayoutClass = computed(() => {
 
 // --- Card refs for celebration positioning ---
 const cardRefs = {};
+
+/** Resolve the card DOM node from a HabitCard component instance (exposed ref). */
+function resolveCardElement(componentInstance) {
+  if (!componentInstance) return null;
+  const exposed = componentInstance.cardRef;
+  if (!exposed) return null;
+  if (exposed instanceof HTMLElement) return exposed;
+  if (typeof exposed === "object" && "value" in exposed) {
+    return exposed.value ?? null;
+  }
+  return null;
+}
+
 function setCardRef(habitId, componentInstance) {
   if (componentInstance) {
     cardRefs[habitId] = componentInstance;
@@ -134,7 +139,7 @@ function completeHabit(habitId) {
 
   // Capture old position BEFORE the server response repositions the card.
   const preCardComponent = cardRefs[habitId];
-  const preCardEl = preCardComponent?.cardRef;
+  const preCardEl = resolveCardElement(preCardComponent);
   const oldRect = preCardEl?.getBoundingClientRect?.() ?? null;
 
   router.post(`/habits/${habitId}/complete/`, {}, {
@@ -151,7 +156,7 @@ function completeHabit(habitId) {
       // the Inertia re-render; fall back to the pre-post element we captured
       // for the FLIP delta. Same :key normally keeps the DOM node stable.
       const cardComponent = cardRefs[habitId];
-      const cardEl = cardComponent?.cardRef ?? preCardEl;
+      const cardEl = resolveCardElement(cardComponent) ?? preCardEl;
       const gotReward = !!(flash?.got_reward && flash?.reward_name);
 
       try {

--- a/frontend/src/themes/index.js
+++ b/frontend/src/themes/index.js
@@ -54,6 +54,10 @@ export const VALID_DENSITIES = new Set([
   'spacious', 'normal', 'compact',
 ]);
 
+export const VALID_HEADER_STYLES = new Set([
+  'plain', 'ring', 'punches', 'xp',
+]);
+
 // ── Default values for all extended config keys ─────────────────────
 export const DEFAULTS = {
   font: {
@@ -79,6 +83,12 @@ export const DEFAULTS = {
     habitList: 'list',
     density: 'normal',
     rewardList: 'list',
+    headerStyle: 'plain',
+  },
+  habitCard: {
+    showOdds: true,
+    showOutcome: false,
+    buttonLabel: 'Done',
   },
 };
 
@@ -658,6 +668,231 @@ export const themes = {
       habitList: 'list',
       density: 'spacious',
       rewardList: 'list',
+    },
+  },
+
+  night_arcade: {
+    name: 'Night Arcade',
+    icon: '🎰',
+    description: 'Charcoal night with gold accents — the reward economy front and center',
+    cssVars: {
+      '--color-bg-primary': '#0d0e13',
+      '--color-bg-card': '#161821',
+      '--color-bg-card-hover': '#1c1f2b',
+      '--color-text-primary': '#eef0f6',
+      '--color-text-secondary': '#9aa1b5',
+      '--color-text-muted': '#6f7688',
+      '--color-accent': '#e9b953',
+      '--color-accent-hover': '#f3d27e',
+      '--color-danger': '#ef4444',
+      '--color-streak-fire': '#f97316',
+    },
+    classes: {
+      card: {
+        rounded: 'rounded-[14px]',
+        shadow: '',
+        border: 'border border-[#232636]',
+        bg: 'bg-bg-card',
+        hoverBg: 'hover:bg-bg-card-hover hover:border-[#2e3247]',
+        extra: '',
+      },
+      button: {
+        rounded: 'rounded-full',
+        padding: 'px-5 py-2',
+        primary: 'bg-transparent border-[1.5px] border-accent text-accent font-bold hover:bg-accent hover:text-[#0d0e13]',
+        secondary: 'bg-transparent text-text-muted hover:text-text-secondary',
+      },
+      input: {
+        base: 'bg-bg-card border border-[#232636] rounded-xl text-text-primary focus:border-accent',
+      },
+      badge: {
+        base: 'rounded-full bg-[#0d0e13] border border-[#232636] text-text-secondary',
+      },
+      select: {
+        base: 'bg-bg-card border border-[#232636] rounded-xl text-text-primary',
+      },
+    },
+    layout: 'sidebar',
+    navStyle: 'default',
+    font: {
+      family: "'Outfit', system-ui, sans-serif",
+      import: 'https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap',
+      weight: '400',
+      size: '16px',
+    },
+    interactions: {
+      habitComplete: 'button-right',
+    },
+    animations: {
+      cardEntrance: 'stagger-fade',
+      hoverMicro: 'glow-border',
+      streakFire: 'pulse-glow',
+    },
+    reward: {
+      displayMode: 'expand-from-card',
+      celebrationComponent: null,
+      rewardPopupVariant: 'particles',
+    },
+    pageLayout: {
+      habitList: 'list',
+      density: 'normal',
+      rewardList: 'list',
+      headerStyle: 'ring',
+    },
+    habitCard: {
+      showOdds: false,
+      showOutcome: true,
+      buttonLabel: '✓ Done',
+    },
+  },
+
+  ticket_stub: {
+    name: 'Ticket Stub',
+    icon: '🎟️',
+    description: 'Warm paper and punch-cards — completing a habit punches your ticket',
+    cssVars: {
+      '--color-bg-primary': '#f5f1e8',
+      '--color-bg-card': '#fffdf8',
+      '--color-bg-card-hover': '#fdf8ee',
+      '--color-text-primary': '#2a2620',
+      '--color-text-secondary': '#6b6354',
+      '--color-text-muted': '#9a9080',
+      '--color-accent': '#d95d39',
+      '--color-accent-hover': '#e5714e',
+      '--color-danger': '#c0392b',
+      '--color-streak-fire': '#e07b39',
+    },
+    classes: {
+      card: {
+        rounded: 'rounded-[10px]',
+        shadow: 'shadow-[0_1px_2px_rgba(42,38,32,0.06)]',
+        border: 'border border-[#ded5c2]',
+        bg: 'bg-bg-card',
+        hoverBg: 'hover:bg-bg-card-hover',
+        extra: '',
+      },
+      button: {
+        rounded: 'rounded-lg',
+        padding: 'px-5 py-2',
+        primary: 'bg-accent text-white font-bold uppercase tracking-wider text-xs shadow-[0_2px_0_#b04526] hover:translate-y-px hover:shadow-[0_1px_0_#b04526] active:translate-y-0.5 active:shadow-none',
+        secondary: 'bg-[#efe9dc] text-text-secondary hover:bg-[#e8e1d1]',
+      },
+      input: {
+        base: 'bg-white border border-[#ded5c2] rounded-lg text-text-primary focus:border-accent',
+      },
+      badge: {
+        base: 'rounded bg-[#efe9dc] text-text-secondary font-mono',
+      },
+      select: {
+        base: 'bg-white border border-[#ded5c2] rounded-lg text-text-primary',
+      },
+    },
+    layout: 'sidebar',
+    navStyle: 'default',
+    font: {
+      family: "'Space Grotesk', system-ui, sans-serif",
+      import: 'https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap',
+      weight: '400',
+      size: '16px',
+    },
+    interactions: {
+      habitComplete: 'button-right',
+    },
+    animations: {
+      cardEntrance: 'slide-up',
+      hoverMicro: 'shadow-lift',
+      streakFire: 'bounce',
+    },
+    reward: {
+      displayMode: 'expand-from-card',
+      celebrationComponent: null,
+      rewardPopupVariant: 'default',
+    },
+    pageLayout: {
+      habitList: 'list',
+      density: 'normal',
+      rewardList: 'list',
+      headerStyle: 'punches',
+    },
+    habitCard: {
+      showOdds: false,
+      showOutcome: true,
+      buttonLabel: 'Punch',
+    },
+  },
+
+  quest_log: {
+    name: 'Quest Log',
+    icon: '⚔️',
+    description: 'Dense RPG ledger — habits as quests, rewards as loot drops',
+    cssVars: {
+      '--color-bg-primary': '#0e1411',
+      '--color-bg-card': '#111a15',
+      '--color-bg-card-hover': '#16241c',
+      '--color-text-primary': '#eef5f0',
+      '--color-text-secondary': '#7d8f84',
+      '--color-text-muted': '#546158',
+      '--color-accent': '#56c288',
+      '--color-accent-hover': '#7ad3a3',
+      '--color-danger': '#e05d5d',
+      '--color-streak-fire': '#e07b39',
+    },
+    classes: {
+      card: {
+        rounded: 'rounded-lg',
+        shadow: '',
+        border: 'border border-[#1e2c23]',
+        bg: 'bg-bg-card',
+        hoverBg: 'hover:bg-bg-card-hover hover:border-[#2a3f31]',
+        extra: '',
+      },
+      button: {
+        rounded: 'rounded-md',
+        padding: 'px-3.5 py-1.5',
+        primary: 'bg-transparent border border-accent text-accent font-semibold hover:bg-accent hover:text-[#0e1411]',
+        secondary: 'bg-transparent text-text-muted hover:text-text-secondary',
+      },
+      input: {
+        base: 'bg-bg-card border border-[#1e2c23] rounded-md text-text-primary focus:border-accent',
+      },
+      badge: {
+        base: 'rounded border border-[#1e2c23] text-text-secondary',
+      },
+      select: {
+        base: 'bg-bg-card border border-[#1e2c23] rounded-md text-text-primary',
+      },
+    },
+    layout: 'sidebar',
+    navStyle: 'default',
+    font: {
+      family: "'IBM Plex Mono', 'Courier New', monospace",
+      import: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600&display=swap',
+      weight: '400',
+      size: '15px',
+    },
+    interactions: {
+      habitComplete: 'button-right',
+    },
+    animations: {
+      cardEntrance: 'none',
+      hoverMicro: 'none',
+      streakFire: 'flicker-flame',
+    },
+    reward: {
+      displayMode: 'toast',
+      celebrationComponent: null,
+      rewardPopupVariant: 'quiet',
+    },
+    pageLayout: {
+      habitList: 'list',
+      density: 'compact',
+      rewardList: 'list',
+      headerStyle: 'xp',
+    },
+    habitCard: {
+      showOdds: false,
+      showOutcome: true,
+      buttonLabel: '[ done ]',
     },
   },
 };

--- a/frontend/tests/HabitCardContent.spec.js
+++ b/frontend/tests/HabitCardContent.spec.js
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import HabitCardContent from "../src/components/HabitCardContent.vue";
+
+vi.mock("../src/composables/useTheme.js", () => ({
+  useTheme: () => ({
+    themeConfig: { value: { habitCard: { showOdds: true, showOutcome: false } } },
+  }),
+}));
 
 const baseHabit = {
   name: "Morning walk",

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -72,6 +72,9 @@ class User(AbstractUser):
         ('dark_focus', 'Dark Focus'),
         ('retro_terminal', 'Retro Terminal'),
         ('nature_forest', 'Nature Forest'),
+        ('night_arcade', 'Night Arcade'),
+        ('ticket_stub', 'Ticket Stub'),
+        ('quest_log', 'Quest Log'),
     ]
     VALID_THEMES = {choice[0] for choice in THEME_CHOICES}
 

--- a/src/habit_reward_project/settings.py
+++ b/src/habit_reward_project/settings.py
@@ -306,6 +306,18 @@ TRUST_X_FORWARDED_FOR = env.bool('TRUST_X_FORWARDED_FOR', default=False)
 # See src/web/services/web_login_service/cache_operations.py.
 CACHE_FAILURE_THRESHOLD = env.int('CACHE_FAILURE_THRESHOLD', default=5)
 
+# Shared cache backend. Web login sets wl_pending:* in the API process; the bot
+# process clears it on Confirm/Deny. LocMemCache is per-process, so local dev
+# with separate `make api` + `make bot` would poll "pending" forever after confirm.
+_DJANGO_CACHE_DIR = BASE_DIR / '.django_cache'
+_DJANGO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': str(_DJANGO_CACHE_DIR),
+    }
+}
+
 
 # =============================================================================
 # INERTIA.JS + VITE CONFIGURATION

--- a/src/web/views/dashboard.py
+++ b/src/web/views/dashboard.py
@@ -37,6 +37,7 @@ async def dashboard(request):
         str(user.id), target_date=today
     )
     completed_habit_ids = {log.habit_id for log in todays_logs}
+    log_map = {log.habit_id: log for log in todays_logs}
 
     # Batch-fetch validated streaks (1 query; returns 0 for broken streaks)
     streak_map = await maybe_await(
@@ -64,6 +65,12 @@ async def dashboard(request):
         )
         reward_chance = round(100 - effective_no_reward)
 
+        log = log_map.get(habit.id)
+        today_result = None
+        if is_completed and log is not None:
+            reward_name = log.reward.name if log.reward_id and log.reward else None
+            today_result = {"gotReward": log.got_reward, "rewardName": reward_name}
+
         habits.append({
             "id": habit.id,
             "name": habit.name,
@@ -71,6 +78,7 @@ async def dashboard(request):
             "streak": streak,
             "completedToday": is_completed,
             "rewardChance": reward_chance,
+            "todayResult": today_result,
         })
 
     # Sort: incomplete first, then completed

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -48,10 +48,15 @@ def _mock_habit(id=1, name="Running", weight=10):
     return h
 
 
-def _mock_habit_log(habit_id=1):
+def _mock_habit_log(habit_id=1, got_reward=False, reward_name=None):
     """Create a mock habit log."""
     log = MagicMock()
     log.habit_id = habit_id
+    log.got_reward = got_reward
+    log.reward_id = 1 if reward_name else None
+    log.reward = MagicMock(name=reward_name) if reward_name else None
+    if log.reward:
+        log.reward.name = reward_name
     return log
 
 

--- a/tests/web/test_dashboard_views.py
+++ b/tests/web/test_dashboard_views.py
@@ -224,8 +224,27 @@ class TestPropStructure:
         assert h["name"] == "Running"
         assert h["streak"] == 3
         assert h["completedToday"] is True
+        assert h["todayResult"] == {"gotReward": False, "rewardName": None}
         assert props["stats"]["completedToday"] == 1
         assert props["stats"]["totalToday"] == 1
+
+    @patch("src.web.views.dashboard.streak_service")
+    @patch("src.web.views.dashboard.habit_log_repository")
+    @patch("src.web.views.dashboard.habit_service")
+    def test_dashboard_includes_today_result_for_completed_habit(
+        self, mock_hs, mock_repo, mock_ss, auth_client
+    ):
+        habit = _mock_habit(id=1, name="Running", weight=10)
+        mock_hs.get_all_active_habits.return_value = [habit]
+        log = _mock_habit_log(habit_id=1, got_reward=True, reward_name="Coffee")
+        mock_repo.get_todays_logs_by_user = AsyncMock(return_value=[log])
+        mock_ss.get_validated_streak_map.return_value = {1: 3}
+
+        response = auth_client.get("/", **INERTIA_HEADERS)
+        _, props = _inertia_props(response)
+
+        h = props["habits"][0]
+        assert h["todayResult"] == {"gotReward": True, "rewardName": "Coffee"}
 
     @patch("src.web.views.rewards.reward_service")
     def test_rewards_prop_structure(self, mock_rs, auth_client):


### PR DESCRIPTION
## Summary
- Adds three new dashboard themes from the approved design review: Night Arcade, Ticket Stub, and Quest Log
- Introduces `DashboardHeader` with theme-specific header styles (ring, punches, xp, plain)
- Shows reward outcome chips on completed habits for the new themes; existing themes stay unchanged
- Exposes `todayResult` on dashboard habit props for frontend outcome chips
- Fixes local dev web login by switching Django cache to shared FileBasedCache (API + bot processes)
- Fixes completion sink animation by resolving card DOM refs correctly and avoiding transform CSS transitions

## Test plan
- [ ] `uv run pytest tests/web/test_dashboard_views.py -q`
- [ ] `cd frontend && npm test -- --run tests/themes.spec.js tests/HabitCardContent.spec.js tests/themeAnimation.spec.js`
- [ ] Switch to each new theme on `/theme/` and confirm picker cards appear
- [ ] Complete a habit on Night Arcade — card sinks down with bounce; outcome chip appears when done
- [ ] Switch back to Dark Focus / Clean Modern — plain header, odds badge, no outcome chip
- [ ] Local login: `make api` + `make bot` + confirm in Telegram redirects to dashboard


Made with [Cursor](https://cursor.com)