### PR TITLE
Add dayforge.habitreward.org to central Caddyfile

### DIFF
--- a/deployment/caddy/Caddyfile
+++ b/deployment/caddy/Caddyfile
@@ -166,6 +166,46 @@ langbot.habitreward.org {
     }
 }
 
+# Day Forge App - Subdomain
+dayforge.habitreward.org {
+    # Automatic HTTPS via Let's Encrypt
+    tls erzhan.sarsenov@gmail.com
+
+    encode zstd gzip
+
+    # Reverse proxy to Django app on host (WhiteNoise serves static).
+    # Django trusts X-Forwarded-Proto via SECURE_PROXY_SSL_HEADER.
+    reverse_proxy host.docker.internal:8006 {
+        header_up X-Forwarded-Proto https
+        health_uri /accounts/login/
+        health_interval 30s
+        health_timeout 10s
+    }
+
+    # Security headers (same as main app)
+    header {
+        # HSTS
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        # Prevent clickjacking
+        X-Frame-Options "SAMEORIGIN"
+        # Prevent MIME sniffing
+        X-Content-Type-Options "nosniff"
+        # Referrer policy
+        Referrer-Policy "strict-origin-when-cross-origin"
+    }
+
+    # Logging
+    log {
+        output file /var/log/caddy/dayforge-access.log
+        format console
+    }
+
+    # Error handling
+    handle_errors {
+        respond "{http.error.status_code} {http.error.status_text}"
+    }
+}
+
 # Redirect www to non-www (if needed)
 www.habitreward.org {
     redir https://habitreward.org{uri} permanent


### PR DESCRIPTION
## Summary
- Adds `dayforge.habitreward.org` reverse-proxy block to `deployment/caddy/Caddyfile` (port 8006, same pattern as fitnesschallenge/launchbuilder/langbot).
- Fixes production outage where day-forge deploy health-checks failed with HTTP 000 / Caddy `444 Domain not configured`.

## Root cause
The dayforge block was only pasted on the droplet during day-forge initial setup and never committed to habit_reward. The **Build and Deploy (Caddy)** workflow replaces the live `Caddyfile` from git on every `main` push — other subdomain blocks survived because they were already in git; dayforge did not.

## Test plan
- [ ] Merge and let **Build and Deploy (Caddy)** run on `main`
- [ ] `curl -fsS -o /dev/null -w "%{http_code}\n" https://dayforge.habitreward.org/accounts/login/` → `200`
- [ ] Re-run day-forge **Deploy** workflow (or push to `main`) → health-check green


Made with [Cursor](https://cursor.com)